### PR TITLE
implement a tiny vm with 10 instructions

### DIFF
--- a/crates/setu-runtime/VM.md
+++ b/crates/setu-runtime/VM.md
@@ -1,100 +1,176 @@
-# Setu Runtime VM (Short Spec)
+# Setu Runtime Move-Style VM
 
-This VM is a small deterministic instruction executor used by `ProgramTx` in `setu-runtime`.
+This document specifies the current programmable VM in `setu-runtime`.
 
-## Goals
+## Overview
 
-- Add programmable execution without full Move VM integration.
-- Keep behavior deterministic and easy to audit.
-- Support basic arithmetic plus control flow (branch/jump).
+Setu VM is a **Move-style typed stack VM with local slots**.
 
-## Transaction Entry
+- Stack-based evaluation (`LdU64`, `Add`, `BrTrue`, `Ret`, etc.)
+- Indexed locals (`CopyLoc`, `MoveLoc`, `StLoc`)
+- Pre-execution verifier (control-flow + type checks)
+- Deterministic interpreter with gas metering
 
-`ProgramTx` contains:
+This VM powers `TransactionType::MoveScript`.
 
-- `instructions: Vec<Instruction>`
-- `inputs: BTreeMap<String, ProgramValue>`
-- `max_steps: Option<u64>`
+## Transaction Format
 
-Execution is triggered via `TransactionType::Program`.
+Programmable execution uses `MoveScriptTx`:
 
-## Value Model
+- `code: Vec<Bytecode>`
+- `locals_sig: Vec<SignatureToken>`
+- `params_sig: Vec<SignatureToken>`
+- `return_sig: Vec<SignatureToken>`
+- `args: Vec<MoveValue>`
+- `type_args: Vec<TypeTag>` (reserved for generic extensions)
+- `max_gas: u64`
+- `input_objects: Vec<ObjectId>`
 
-`ProgramValue`:
+`Transaction::new_move_script(...)` copies `input_objects` into transaction-level dependencies.
+
+## Runtime Types
+
+`MoveValue`:
 
 - `U64(u64)`
 - `Bool(bool)`
+- `Address(Address)`
+- `Vector(Vec<MoveValue>)`
 
-Registers are fixed-size (`16`) and initialized to `U64(0)`.
+`SignatureToken`:
 
-## Instruction Set (10 opcodes)
+- `U64`
+- `Bool`
+- `Address`
+- `Vector(Box<SignatureToken>)`
 
-1. `Nop`
-2. `Const { dst, value }`
-3. `Mov { dst, src }`
-4. `BinOp { op, dst, lhs, rhs }`
-5. `Cmp { op, dst, lhs, rhs }`
-6. `LoadInput { dst, key }`
-7. `StoreOutput { key, src }`
-8. `Jump { pc }`
-9. `JumpIf { cond, pc }`
-10. `Halt { success, message }`
+`TypeTag` currently mirrors simple base/vector types and is reserved for future generic handling.
 
-`BinOp` supports checked arithmetic/bitwise ops:
-`Add`, `Sub`, `Mul`, `Div`, `Mod`, `BitAnd`, `BitOr`, `BitXor`.
+## Bytecode Set (Current)
 
-`Cmp` supports:
-`Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`.
+Constants:
 
-## Determinism and Safety
+- `LdU64(u64)`, `LdTrue`, `LdFalse`
 
-Before execution:
+Locals/stack:
 
-- Validate instruction count (`<= 4096`).
-- Validate jump targets are in range.
-- Validate register indices are valid.
-- Validate `max_steps` (`1..=100000`, default `10000`).
+- `CopyLoc(u8)`, `MoveLoc(u8)`, `StLoc(u8)`, `Pop`
 
-During execution:
+Arithmetic:
 
-- Enforce step limit.
-- Fail on overflow/div-by-zero/mod-by-zero.
-- Fail on missing input key.
-- Require explicit `Halt`; falling off program is an error.
+- `Add`, `Sub`, `Mul`, `Div`, `Mod`
 
-## Output
+Comparison:
 
-Current VM phase returns:
+- `Eq`, `Neq`, `Lt`, `Le`, `Gt`, `Ge`
 
-- `ExecutionOutput.success` from `Halt.success`
-- `ExecutionOutput.message` from `Halt.message` (or default message)
-- `ExecutionOutput.query_result` containing stored output key-values
-- No state writes yet (`state_changes` is empty in this phase)
+Control flow:
 
-## Minimal Example
+- `BrTrue(u16)`, `BrFalse(u16)`, `Branch(u16)`
 
-```rust
-use std::collections::BTreeMap;
-use setu_runtime::{Instruction, ProgramValue, BinaryOp, CompareOp, Transaction};
-use setu_types::Address;
+Termination:
 
-let tx = Transaction::new_program(
-    Address::from("alice"),
-    vec![
-        Instruction::Const { dst: 0, value: ProgramValue::U64(2) },
-        Instruction::Const { dst: 1, value: ProgramValue::U64(3) },
-        Instruction::BinOp { op: BinaryOp::Add, dst: 2, lhs: 0, rhs: 1 }, // r2 = 5
-        Instruction::Const { dst: 3, value: ProgramValue::U64(4) },
-        Instruction::Cmp { op: CompareOp::Gt, dst: 4, lhs: 2, rhs: 3 },    // r4 = true
-        Instruction::JumpIf { cond: 4, pc: 8 },
-        Instruction::Const { dst: 5, value: ProgramValue::U64(0) },
-        Instruction::Jump { pc: 9 },
-        Instruction::Const { dst: 5, value: ProgramValue::U64(1) },
-        Instruction::StoreOutput { key: "ok".to_string(), src: 5 },
-        Instruction::Halt { success: true, message: Some("done".to_string()) },
-    ],
-    BTreeMap::new(),
-    None,
-);
-```
+- `Ret`
+- `Abort { code: u64, message: Option<String> }`
 
+## Verification Pipeline
+
+Before execution, the VM verifies:
+
+1. Structural envelope:
+- non-empty code
+- code length bound
+- locals count bound
+- `params_sig.len() <= locals_sig.len()`
+- `args.len() == params_sig.len()`
+- `max_gas > 0`
+
+2. Argument type compatibility:
+- each `arg` matches `params_sig`
+
+3. Bytecode control-flow and type safety:
+- valid branch targets
+- stack underflow prevention via abstract interpretation
+- opcode operand type checks
+- join-point stack state consistency
+- return stack matches `return_sig`
+- at least one reachable terminal instruction (`Ret` or `Abort`)
+
+If verification fails, execution is rejected with `RuntimeError::InvalidTransaction`.
+
+## Execution Semantics
+
+Interpreter model:
+
+- `locals: Vec<Option<MoveValue>>`, initialized from `args`
+- `stack: Vec<MoveValue>`
+- `pc: usize`
+- per-op gas charging
+
+Current runtime bounds:
+
+- `MAX_CODE_LENGTH = 4096`
+- `MAX_LOCALS = 256`
+- `MAX_STACK_DEPTH = 1024`
+- `MAX_STEPS = 100000`
+
+Arithmetic is checked:
+
+- overflow/underflow -> error
+- division/mod by zero -> error
+
+Gas behavior:
+
+- fixed gas cost table by opcode
+- execution aborts with out-of-gas error when budget is insufficient
+
+Termination behavior:
+
+- `Ret`: success, stack must match `return_sig`, return values emitted in `query_result.returns`
+- `Abort`: non-success `ExecutionOutput` with `abort_code` in `query_result`
+
+## Output Contract
+
+For `MoveScript` execution:
+
+- `ExecutionOutput.success`: `true` on `Ret`, `false` on `Abort`
+- `ExecutionOutput.message`: execution/abort message
+- `ExecutionOutput.query_result`:
+  - `returns`: return values (on `Ret`)
+  - `gas_used`: consumed gas
+  - `abort_code`: on `Abort`
+- `state_changes`, `created_objects`, `deleted_objects`: empty in current phase
+
+Transfer/query paths are unchanged.
+
+## Example
+
+High-level shape of a script:
+
+1. load params from locals
+2. compute and compare
+3. branch
+4. push return value
+5. `Ret`
+
+Reference tests:
+
+- `test_move_script_branch_and_return`
+- `test_move_script_out_of_gas`
+
+in `crates/setu-runtime/src/executor.rs`.
+
+## Current Scope and Next Steps
+
+Implemented scope:
+
+- typed stack VM core
+- locals handling
+- verifier
+- gas metering
+
+Not yet implemented:
+
+- module/function call model (`Call`)
+- storage/resource bytecodes (`Exists`, `MoveFrom`, `MoveTo`)
+- struct/resource semantics (`Pack`, `Unpack`, abilities)

--- a/crates/setu-runtime/src/executor.rs
+++ b/crates/setu-runtime/src/executor.rs
@@ -3,12 +3,12 @@
 use crate::error::{RuntimeError, RuntimeResult};
 use crate::state::StateStore;
 use crate::transaction::{
-    BinaryOp, CompareOp, Instruction, ProgramTx, ProgramValue, QueryTx, QueryType, Transaction,
+    Bytecode, MoveScriptTx, MoveValue, QueryTx, QueryType, SignatureToken, Transaction,
     TransactionType, TransferTx,
 };
 use serde::{Deserialize, Serialize};
 use setu_types::{create_typed_coin, Address, CoinType, ObjectId};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{HashMap, VecDeque};
 use tracing::{debug, info, warn};
 
 /// Execution context
@@ -92,7 +92,7 @@ impl<S: StateStore> RuntimeExecutor<S> {
         let result = match &tx.tx_type {
             TransactionType::Transfer(transfer_tx) => self.execute_transfer(tx, transfer_tx, ctx),
             TransactionType::Query(query_tx) => self.execute_query(tx, query_tx, ctx),
-            TransactionType::Program(program_tx) => self.execute_program(tx, program_tx, ctx),
+            TransactionType::MoveScript(script_tx) => self.execute_move_script(tx, script_tx, ctx),
         };
 
         match &result {
@@ -323,265 +323,611 @@ impl<S: StateStore> RuntimeExecutor<S> {
         })
     }
 
-    /// Execute a programmable transaction using a compact deterministic instruction set.
-    fn execute_program(
+    /// Execute Move-style script (typed stack + locals).
+    fn execute_move_script(
         &mut self,
         _tx: &Transaction,
-        program_tx: &ProgramTx,
+        script_tx: &MoveScriptTx,
         _ctx: &ExecutionContext,
     ) -> RuntimeResult<ExecutionOutput> {
-        const REGISTER_COUNT: usize = 16;
-        const DEFAULT_MAX_STEPS: u64 = 10_000;
-        const HARD_MAX_STEPS: u64 = 100_000;
-        const MAX_PROGRAM_LENGTH: usize = 4_096;
+        const MAX_CODE_LENGTH: usize = 4_096;
+        const MAX_LOCALS: usize = 256;
+        const MAX_STACK_DEPTH: usize = 1_024;
+        const MAX_STEPS: usize = 100_000;
 
-        if program_tx.instructions.is_empty() {
-            return Err(RuntimeError::InvalidTransaction(
-                "Program has no instructions".to_string(),
-            ));
+        self.verify_move_script(script_tx, MAX_CODE_LENGTH, MAX_LOCALS)?;
+
+        let mut gas_remaining = script_tx.max_gas;
+        let mut steps = 0usize;
+        let mut pc = 0usize;
+        let mut stack: Vec<MoveValue> = Vec::new();
+        let mut locals: Vec<Option<MoveValue>> = vec![None; script_tx.locals_sig.len()];
+
+        for (i, arg) in script_tx.args.iter().enumerate() {
+            locals[i] = Some(arg.clone());
         }
 
-        if program_tx.instructions.len() > MAX_PROGRAM_LENGTH {
-            return Err(RuntimeError::InvalidTransaction(format!(
-                "Program too large: {} > {} instructions",
-                program_tx.instructions.len(),
-                MAX_PROGRAM_LENGTH
-            )));
-        }
-
-        let max_steps = program_tx.max_steps.unwrap_or(DEFAULT_MAX_STEPS);
-        if max_steps == 0 || max_steps > HARD_MAX_STEPS {
-            return Err(RuntimeError::InvalidTransaction(format!(
-                "Invalid max_steps: {} (allowed: 1..={})",
-                max_steps, HARD_MAX_STEPS
-            )));
-        }
-
-        self.validate_program(program_tx, REGISTER_COUNT)?;
-
-        let mut registers = vec![ProgramValue::U64(0); REGISTER_COUNT];
-        let mut outputs: BTreeMap<String, ProgramValue> = BTreeMap::new();
-        let mut pc: usize = 0;
-        let mut steps: u64 = 0;
-        let mut halt_result: Option<(bool, Option<String>)> = None;
-
-        while pc < program_tx.instructions.len() {
-            if steps >= max_steps {
+        loop {
+            if pc >= script_tx.code.len() {
                 return Err(RuntimeError::InvalidTransaction(format!(
-                    "Program step limit exceeded at pc={} (max_steps={})",
-                    pc, max_steps
+                    "Program counter out of range: {}",
+                    pc
+                )));
+            }
+
+            if steps >= MAX_STEPS {
+                return Err(RuntimeError::InvalidTransaction(format!(
+                    "Step limit exceeded at pc={}",
+                    pc
                 )));
             }
             steps += 1;
 
-            match &program_tx.instructions[pc] {
-                Instruction::Nop => {
+            let op = &script_tx.code[pc];
+            let gas_cost = Self::opcode_gas_cost(op);
+            if gas_remaining < gas_cost {
+                return Err(RuntimeError::InvalidTransaction(format!(
+                    "Out of gas at pc={} (required={}, remaining={})",
+                    pc, gas_cost, gas_remaining
+                )));
+            }
+            gas_remaining -= gas_cost;
+
+            match op {
+                Bytecode::LdU64(v) => {
+                    stack.push(MoveValue::U64(*v));
                     pc += 1;
                 }
-                Instruction::Const { dst, value } => {
-                    registers[*dst as usize] = value.clone();
+                Bytecode::LdTrue => {
+                    stack.push(MoveValue::Bool(true));
                     pc += 1;
                 }
-                Instruction::Mov { dst, src } => {
-                    registers[*dst as usize] = registers[*src as usize].clone();
+                Bytecode::LdFalse => {
+                    stack.push(MoveValue::Bool(false));
                     pc += 1;
                 }
-                Instruction::BinOp { op, dst, lhs, rhs } => {
-                    let left = Self::read_u64(&registers, *lhs, pc)?;
-                    let right = Self::read_u64(&registers, *rhs, pc)?;
-                    let result = Self::execute_binop(op, left, right, pc)?;
-                    registers[*dst as usize] = ProgramValue::U64(result);
-                    pc += 1;
-                }
-                Instruction::Cmp { op, dst, lhs, rhs } => {
-                    let left = Self::read_u64(&registers, *lhs, pc)?;
-                    let right = Self::read_u64(&registers, *rhs, pc)?;
-                    let result = Self::execute_cmp(op, left, right);
-                    registers[*dst as usize] = ProgramValue::Bool(result);
-                    pc += 1;
-                }
-                Instruction::LoadInput { dst, key } => {
-                    let value = program_tx.inputs.get(key).ok_or_else(|| {
+                Bytecode::CopyLoc(local_idx) => {
+                    let idx = *local_idx as usize;
+                    let val = locals[idx].clone().ok_or_else(|| {
                         RuntimeError::InvalidTransaction(format!(
-                            "Missing program input '{}' at pc={}",
-                            key, pc
+                            "CopyLoc on uninitialized local {} at pc={}",
+                            idx, pc
                         ))
                     })?;
-                    registers[*dst as usize] = value.clone();
+                    stack.push(val);
                     pc += 1;
                 }
-                Instruction::StoreOutput { key, src } => {
-                    outputs.insert(key.clone(), registers[*src as usize].clone());
+                Bytecode::MoveLoc(local_idx) => {
+                    let idx = *local_idx as usize;
+                    let val = locals[idx].take().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "MoveLoc on uninitialized local {} at pc={}",
+                            idx, pc
+                        ))
+                    })?;
+                    stack.push(val);
                     pc += 1;
                 }
-                Instruction::Jump { pc: target } => {
-                    pc = *target as usize;
+                Bytecode::StLoc(local_idx) => {
+                    let idx = *local_idx as usize;
+                    let val = Self::pop_value(&mut stack, pc)?;
+                    let expected_ty = &script_tx.locals_sig[idx];
+                    Self::ensure_value_type(&val, expected_ty, pc)?;
+                    locals[idx] = Some(val);
+                    pc += 1;
                 }
-                Instruction::JumpIf { cond, pc: target } => {
-                    let condition = Self::read_bool(&registers, *cond, pc)?;
-                    if condition {
+                Bytecode::Pop => {
+                    let _ = Self::pop_value(&mut stack, pc)?;
+                    pc += 1;
+                }
+                Bytecode::Add => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    let result = lhs.checked_add(rhs).ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Arithmetic overflow at pc={}",
+                            pc
+                        ))
+                    })?;
+                    stack.push(MoveValue::U64(result));
+                    pc += 1;
+                }
+                Bytecode::Sub => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    let result = lhs.checked_sub(rhs).ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Arithmetic underflow at pc={}",
+                            pc
+                        ))
+                    })?;
+                    stack.push(MoveValue::U64(result));
+                    pc += 1;
+                }
+                Bytecode::Mul => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    let result = lhs.checked_mul(rhs).ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Arithmetic overflow at pc={}",
+                            pc
+                        ))
+                    })?;
+                    stack.push(MoveValue::U64(result));
+                    pc += 1;
+                }
+                Bytecode::Div => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    if rhs == 0 {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Division by zero at pc={}",
+                            pc
+                        )));
+                    }
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    stack.push(MoveValue::U64(lhs / rhs));
+                    pc += 1;
+                }
+                Bytecode::Mod => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    if rhs == 0 {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Modulo by zero at pc={}",
+                            pc
+                        )));
+                    }
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    stack.push(MoveValue::U64(lhs % rhs));
+                    pc += 1;
+                }
+                Bytecode::Eq => {
+                    let rhs = Self::pop_value(&mut stack, pc)?;
+                    let lhs = Self::pop_value(&mut stack, pc)?;
+                    stack.push(MoveValue::Bool(lhs == rhs));
+                    pc += 1;
+                }
+                Bytecode::Neq => {
+                    let rhs = Self::pop_value(&mut stack, pc)?;
+                    let lhs = Self::pop_value(&mut stack, pc)?;
+                    stack.push(MoveValue::Bool(lhs != rhs));
+                    pc += 1;
+                }
+                Bytecode::Lt => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    stack.push(MoveValue::Bool(lhs < rhs));
+                    pc += 1;
+                }
+                Bytecode::Le => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    stack.push(MoveValue::Bool(lhs <= rhs));
+                    pc += 1;
+                }
+                Bytecode::Gt => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    stack.push(MoveValue::Bool(lhs > rhs));
+                    pc += 1;
+                }
+                Bytecode::Ge => {
+                    let rhs = Self::pop_u64(&mut stack, pc)?;
+                    let lhs = Self::pop_u64(&mut stack, pc)?;
+                    stack.push(MoveValue::Bool(lhs >= rhs));
+                    pc += 1;
+                }
+                Bytecode::BrTrue(target) => {
+                    let cond = Self::pop_bool(&mut stack, pc)?;
+                    if cond {
                         pc = *target as usize;
                     } else {
                         pc += 1;
                     }
                 }
-                Instruction::Halt { success, message } => {
-                    halt_result = Some((*success, message.clone()));
-                    break;
+                Bytecode::BrFalse(target) => {
+                    let cond = Self::pop_bool(&mut stack, pc)?;
+                    if !cond {
+                        pc = *target as usize;
+                    } else {
+                        pc += 1;
+                    }
+                }
+                Bytecode::Branch(target) => {
+                    pc = *target as usize;
+                }
+                Bytecode::Ret => {
+                    if stack.len() != script_tx.return_sig.len() {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Return stack length mismatch at pc={}: expected {}, got {}",
+                            pc,
+                            script_tx.return_sig.len(),
+                            stack.len()
+                        )));
+                    }
+                    for (value, ty) in stack.iter().zip(script_tx.return_sig.iter()) {
+                        Self::ensure_value_type(value, ty, pc)?;
+                    }
+
+                    let return_values_json: Vec<serde_json::Value> =
+                        stack.into_iter().map(Self::move_value_to_json).collect();
+                    let query_result = serde_json::json!({
+                        "returns": return_values_json,
+                        "gas_used": script_tx.max_gas.saturating_sub(gas_remaining),
+                    });
+
+                    return Ok(ExecutionOutput {
+                        success: true,
+                        message: Some(format!("Move script executed in {} steps", steps)),
+                        state_changes: vec![],
+                        created_objects: vec![],
+                        deleted_objects: vec![],
+                        query_result: Some(query_result),
+                    });
+                }
+                Bytecode::Abort { code, message } => {
+                    return Ok(ExecutionOutput {
+                        success: false,
+                        message: Some(match message {
+                            Some(m) => format!("Abort({}): {}", code, m),
+                            None => format!("Abort({})", code),
+                        }),
+                        state_changes: vec![],
+                        created_objects: vec![],
+                        deleted_objects: vec![],
+                        query_result: Some(serde_json::json!({
+                            "abort_code": code,
+                            "gas_used": script_tx.max_gas.saturating_sub(gas_remaining),
+                        })),
+                    });
+                }
+            }
+
+            if stack.len() > MAX_STACK_DEPTH {
+                return Err(RuntimeError::InvalidTransaction(format!(
+                    "Stack depth exceeded limit {} at pc={}",
+                    MAX_STACK_DEPTH, pc
+                )));
+            }
+        }
+    }
+
+    fn verify_move_script(
+        &self,
+        script_tx: &MoveScriptTx,
+        max_code_len: usize,
+        max_locals: usize,
+    ) -> RuntimeResult<()> {
+        if script_tx.code.is_empty() {
+            return Err(RuntimeError::InvalidTransaction(
+                "Move script has empty code".to_string(),
+            ));
+        }
+        if script_tx.code.len() > max_code_len {
+            return Err(RuntimeError::InvalidTransaction(format!(
+                "Move script too large: {} > {} instructions",
+                script_tx.code.len(),
+                max_code_len
+            )));
+        }
+        if script_tx.locals_sig.len() > max_locals {
+            return Err(RuntimeError::InvalidTransaction(format!(
+                "Too many locals: {} > {}",
+                script_tx.locals_sig.len(),
+                max_locals
+            )));
+        }
+        if script_tx.params_sig.len() > script_tx.locals_sig.len() {
+            return Err(RuntimeError::InvalidTransaction(format!(
+                "params_sig longer than locals_sig: {} > {}",
+                script_tx.params_sig.len(),
+                script_tx.locals_sig.len()
+            )));
+        }
+        if script_tx.args.len() != script_tx.params_sig.len() {
+            return Err(RuntimeError::InvalidTransaction(format!(
+                "Argument length mismatch: expected {}, got {}",
+                script_tx.params_sig.len(),
+                script_tx.args.len()
+            )));
+        }
+        if script_tx.max_gas == 0 {
+            return Err(RuntimeError::InvalidTransaction(
+                "max_gas must be greater than zero".to_string(),
+            ));
+        }
+
+        for (arg, sig) in script_tx.args.iter().zip(script_tx.params_sig.iter()) {
+            Self::ensure_value_matches_sig(arg, sig)?;
+        }
+
+        self.verify_control_flow_and_types(script_tx)
+    }
+
+    fn verify_control_flow_and_types(&self, script_tx: &MoveScriptTx) -> RuntimeResult<()> {
+        let mut queue: VecDeque<(usize, Vec<SignatureToken>)> = VecDeque::new();
+        let mut seen: HashMap<usize, Vec<SignatureToken>> = HashMap::new();
+        let mut has_terminal = false;
+        queue.push_back((0, Vec::new()));
+
+        while let Some((pc, stack_state)) = queue.pop_front() {
+            if pc >= script_tx.code.len() {
+                return Err(RuntimeError::InvalidTransaction(format!(
+                    "Invalid pc {} during verification",
+                    pc
+                )));
+            }
+
+            if let Some(existing) = seen.get(&pc) {
+                if existing != &stack_state {
+                    return Err(RuntimeError::InvalidTransaction(format!(
+                        "Incompatible stack state at join point pc={}",
+                        pc
+                    )));
+                }
+                continue;
+            }
+            seen.insert(pc, stack_state.clone());
+
+            let mut stack = stack_state;
+            let op = &script_tx.code[pc];
+            let mut push_succ =
+                |next_pc: usize, next_stack: Vec<SignatureToken>| -> RuntimeResult<()> {
+                    if next_pc >= script_tx.code.len() {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Control flow exits code range at pc={}",
+                            pc
+                        )));
+                    }
+                    queue.push_back((next_pc, next_stack));
+                    Ok(())
+                };
+
+            match op {
+                Bytecode::LdU64(_) => {
+                    stack.push(SignatureToken::U64);
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::LdTrue | Bytecode::LdFalse => {
+                    stack.push(SignatureToken::Bool);
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::CopyLoc(idx) | Bytecode::MoveLoc(idx) => {
+                    let local_idx = *idx as usize;
+                    let ty = script_tx.locals_sig.get(local_idx).ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Local index out of bounds {} at pc={}",
+                            local_idx, pc
+                        ))
+                    })?;
+                    stack.push(ty.clone());
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::StLoc(idx) => {
+                    let local_idx = *idx as usize;
+                    let ty = script_tx.locals_sig.get(local_idx).ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Local index out of bounds {} at pc={}",
+                            local_idx, pc
+                        ))
+                    })?;
+                    let top = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Stack underflow at StLoc pc={}",
+                            pc
+                        ))
+                    })?;
+                    if &top != ty {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Type mismatch at StLoc pc={}",
+                            pc
+                        )));
+                    }
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::Pop => {
+                    let _ = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Stack underflow at Pop pc={}",
+                            pc
+                        ))
+                    })?;
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::Add | Bytecode::Sub | Bytecode::Mul | Bytecode::Div | Bytecode::Mod => {
+                    let rhs = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!("Stack underflow at pc={}", pc))
+                    })?;
+                    let lhs = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!("Stack underflow at pc={}", pc))
+                    })?;
+                    if rhs != SignatureToken::U64 || lhs != SignatureToken::U64 {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Arithmetic expects U64 at pc={}",
+                            pc
+                        )));
+                    }
+                    stack.push(SignatureToken::U64);
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::Eq | Bytecode::Neq => {
+                    let rhs = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!("Stack underflow at pc={}", pc))
+                    })?;
+                    let lhs = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!("Stack underflow at pc={}", pc))
+                    })?;
+                    if rhs != lhs {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Eq/Neq operand type mismatch at pc={}",
+                            pc
+                        )));
+                    }
+                    stack.push(SignatureToken::Bool);
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::Lt | Bytecode::Le | Bytecode::Gt | Bytecode::Ge => {
+                    let rhs = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!("Stack underflow at pc={}", pc))
+                    })?;
+                    let lhs = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!("Stack underflow at pc={}", pc))
+                    })?;
+                    if rhs != SignatureToken::U64 || lhs != SignatureToken::U64 {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Comparison expects U64 at pc={}",
+                            pc
+                        )));
+                    }
+                    stack.push(SignatureToken::Bool);
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::BrTrue(target) | Bytecode::BrFalse(target) => {
+                    let cond = stack.pop().ok_or_else(|| {
+                        RuntimeError::InvalidTransaction(format!(
+                            "Stack underflow at branch pc={}",
+                            pc
+                        ))
+                    })?;
+                    if cond != SignatureToken::Bool {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Branch condition must be Bool at pc={}",
+                            pc
+                        )));
+                    }
+                    let target_pc = *target as usize;
+                    if target_pc >= script_tx.code.len() {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Branch target {} out of bounds at pc={}",
+                            target_pc, pc
+                        )));
+                    }
+                    push_succ(target_pc, stack.clone())?;
+                    push_succ(pc + 1, stack)?;
+                }
+                Bytecode::Branch(target) => {
+                    let target_pc = *target as usize;
+                    if target_pc >= script_tx.code.len() {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Branch target {} out of bounds at pc={}",
+                            target_pc, pc
+                        )));
+                    }
+                    push_succ(target_pc, stack)?;
+                }
+                Bytecode::Ret => {
+                    if stack != script_tx.return_sig {
+                        return Err(RuntimeError::InvalidTransaction(format!(
+                            "Return signature mismatch at pc={}",
+                            pc
+                        )));
+                    }
+                    has_terminal = true;
+                }
+                Bytecode::Abort { .. } => {
+                    has_terminal = true;
                 }
             }
         }
 
-        let (success, message) = halt_result.ok_or_else(|| {
-            RuntimeError::InvalidTransaction(
-                "Program terminated without Halt instruction".to_string(),
-            )
-        })?;
-
-        let mut query_map = serde_json::Map::new();
-        for (k, v) in outputs {
-            query_map.insert(k, Self::program_value_to_json(v));
+        if !has_terminal {
+            return Err(RuntimeError::InvalidTransaction(
+                "Script has no reachable terminal instruction (Ret/Abort)".to_string(),
+            ));
         }
 
-        let query_result = serde_json::Value::Object(query_map);
-        Ok(ExecutionOutput {
-            success,
-            message: message.or_else(|| Some(format!("Program executed in {} steps", steps))),
-            state_changes: vec![],
-            created_objects: vec![],
-            deleted_objects: vec![],
-            query_result: Some(query_result),
+        Ok(())
+    }
+
+    fn opcode_gas_cost(op: &Bytecode) -> u64 {
+        match op {
+            Bytecode::LdU64(_) | Bytecode::LdTrue | Bytecode::LdFalse => 1,
+            Bytecode::CopyLoc(_) | Bytecode::MoveLoc(_) | Bytecode::StLoc(_) | Bytecode::Pop => 1,
+            Bytecode::Add | Bytecode::Sub | Bytecode::Mul => 2,
+            Bytecode::Div | Bytecode::Mod => 3,
+            Bytecode::Eq
+            | Bytecode::Neq
+            | Bytecode::Lt
+            | Bytecode::Le
+            | Bytecode::Gt
+            | Bytecode::Ge => 1,
+            Bytecode::BrTrue(_) | Bytecode::BrFalse(_) | Bytecode::Branch(_) => 1,
+            Bytecode::Ret => 1,
+            Bytecode::Abort { .. } => 1,
+        }
+    }
+
+    fn pop_value(stack: &mut Vec<MoveValue>, pc: usize) -> RuntimeResult<MoveValue> {
+        stack.pop().ok_or_else(|| {
+            RuntimeError::InvalidTransaction(format!("Stack underflow at pc={}", pc))
         })
     }
 
-    fn validate_program(&self, program_tx: &ProgramTx, register_count: usize) -> RuntimeResult<()> {
-        let program_len = program_tx.instructions.len();
-        for (pc, instr) in program_tx.instructions.iter().enumerate() {
-            match instr {
-                Instruction::Nop => {}
-                Instruction::Const { dst, .. } => {
-                    Self::validate_register(*dst, register_count, pc)?;
-                }
-                Instruction::Mov { dst, src } => {
-                    Self::validate_register(*dst, register_count, pc)?;
-                    Self::validate_register(*src, register_count, pc)?;
-                }
-                Instruction::BinOp { dst, lhs, rhs, .. } => {
-                    Self::validate_register(*dst, register_count, pc)?;
-                    Self::validate_register(*lhs, register_count, pc)?;
-                    Self::validate_register(*rhs, register_count, pc)?;
-                }
-                Instruction::Cmp { dst, lhs, rhs, .. } => {
-                    Self::validate_register(*dst, register_count, pc)?;
-                    Self::validate_register(*lhs, register_count, pc)?;
-                    Self::validate_register(*rhs, register_count, pc)?;
-                }
-                Instruction::LoadInput { dst, .. } => {
-                    Self::validate_register(*dst, register_count, pc)?;
-                }
-                Instruction::StoreOutput { src, .. } => {
-                    Self::validate_register(*src, register_count, pc)?;
-                }
-                Instruction::Jump { pc: target } => {
-                    Self::validate_jump(*target, program_len, pc)?;
-                }
-                Instruction::JumpIf { cond, pc: target } => {
-                    Self::validate_register(*cond, register_count, pc)?;
-                    Self::validate_jump(*target, program_len, pc)?;
-                }
-                Instruction::Halt { .. } => {}
-            }
-        }
-        Ok(())
-    }
-
-    fn validate_register(reg: u8, register_count: usize, pc: usize) -> RuntimeResult<()> {
-        if reg as usize >= register_count {
-            return Err(RuntimeError::InvalidTransaction(format!(
-                "Invalid register r{} at pc={} (max register index: {})",
-                reg,
-                pc,
-                register_count.saturating_sub(1)
-            )));
-        }
-        Ok(())
-    }
-
-    fn validate_jump(target: u16, program_len: usize, pc: usize) -> RuntimeResult<()> {
-        if target as usize >= program_len {
-            return Err(RuntimeError::InvalidTransaction(format!(
-                "Invalid jump target {} at pc={} (program length: {})",
-                target, pc, program_len
-            )));
-        }
-        Ok(())
-    }
-
-    fn read_u64(registers: &[ProgramValue], reg: u8, pc: usize) -> RuntimeResult<u64> {
-        match &registers[reg as usize] {
-            ProgramValue::U64(v) => Ok(*v),
-            ProgramValue::Bool(_) => Err(RuntimeError::InvalidTransaction(format!(
-                "Type error at pc={}: expected u64 in r{}, found bool",
-                pc, reg
+    fn pop_u64(stack: &mut Vec<MoveValue>, pc: usize) -> RuntimeResult<u64> {
+        match Self::pop_value(stack, pc)? {
+            MoveValue::U64(v) => Ok(v),
+            other => Err(RuntimeError::InvalidTransaction(format!(
+                "Type error at pc={}: expected U64, found {:?}",
+                pc, other
             ))),
         }
     }
 
-    fn read_bool(registers: &[ProgramValue], reg: u8, _pc: usize) -> RuntimeResult<bool> {
-        match &registers[reg as usize] {
-            ProgramValue::Bool(v) => Ok(*v),
-            ProgramValue::U64(v) => Ok(*v != 0),
+    fn pop_bool(stack: &mut Vec<MoveValue>, pc: usize) -> RuntimeResult<bool> {
+        match Self::pop_value(stack, pc)? {
+            MoveValue::Bool(v) => Ok(v),
+            other => Err(RuntimeError::InvalidTransaction(format!(
+                "Type error at pc={}: expected Bool, found {:?}",
+                pc, other
+            ))),
         }
     }
 
-    fn execute_binop(op: &BinaryOp, lhs: u64, rhs: u64, pc: usize) -> RuntimeResult<u64> {
-        let result = match op {
-            BinaryOp::Add => lhs.checked_add(rhs),
-            BinaryOp::Sub => lhs.checked_sub(rhs),
-            BinaryOp::Mul => lhs.checked_mul(rhs),
-            BinaryOp::Div => {
-                if rhs == 0 {
-                    return Err(RuntimeError::InvalidTransaction(format!(
-                        "Division by zero at pc={}",
-                        pc
-                    )));
-                }
-                Some(lhs / rhs)
-            }
-            BinaryOp::Mod => {
-                if rhs == 0 {
-                    return Err(RuntimeError::InvalidTransaction(format!(
-                        "Modulo by zero at pc={}",
-                        pc
-                    )));
-                }
-                Some(lhs % rhs)
-            }
-            BinaryOp::BitAnd => Some(lhs & rhs),
-            BinaryOp::BitOr => Some(lhs | rhs),
-            BinaryOp::BitXor => Some(lhs ^ rhs),
-        };
-
-        result.ok_or_else(|| {
-            RuntimeError::InvalidTransaction(format!("Arithmetic overflow at pc={} ({:?})", pc, op))
-        })
-    }
-
-    fn execute_cmp(op: &CompareOp, lhs: u64, rhs: u64) -> bool {
-        match op {
-            CompareOp::Eq => lhs == rhs,
-            CompareOp::Ne => lhs != rhs,
-            CompareOp::Lt => lhs < rhs,
-            CompareOp::Le => lhs <= rhs,
-            CompareOp::Gt => lhs > rhs,
-            CompareOp::Ge => lhs >= rhs,
+    fn ensure_value_type(
+        value: &MoveValue,
+        expected: &SignatureToken,
+        pc: usize,
+    ) -> RuntimeResult<()> {
+        if Self::value_matches_sig(value, expected) {
+            Ok(())
+        } else {
+            Err(RuntimeError::InvalidTransaction(format!(
+                "Type mismatch at pc={}: value {:?} does not match {:?}",
+                pc, value, expected
+            )))
         }
     }
 
-    fn program_value_to_json(value: ProgramValue) -> serde_json::Value {
+    fn ensure_value_matches_sig(value: &MoveValue, expected: &SignatureToken) -> RuntimeResult<()> {
+        if Self::value_matches_sig(value, expected) {
+            Ok(())
+        } else {
+            Err(RuntimeError::InvalidTransaction(format!(
+                "Argument type mismatch: value {:?} does not match {:?}",
+                value, expected
+            )))
+        }
+    }
+
+    fn value_matches_sig(value: &MoveValue, expected: &SignatureToken) -> bool {
+        match (value, expected) {
+            (MoveValue::Bool(_), SignatureToken::Bool) => true,
+            (MoveValue::U64(_), SignatureToken::U64) => true,
+            (MoveValue::Address(_), SignatureToken::Address) => true,
+            (MoveValue::Vector(values), SignatureToken::Vector(inner)) => {
+                values.iter().all(|v| Self::value_matches_sig(v, inner))
+            }
+            _ => false,
+        }
+    }
+
+    fn move_value_to_json(value: MoveValue) -> serde_json::Value {
         match value {
-            ProgramValue::U64(v) => serde_json::json!(v),
-            ProgramValue::Bool(v) => serde_json::json!(v),
+            MoveValue::U64(v) => serde_json::json!(v),
+            MoveValue::Bool(v) => serde_json::json!(v),
+            MoveValue::Address(addr) => serde_json::json!(addr.to_string()),
+            MoveValue::Vector(vals) => {
+                serde_json::Value::Array(vals.into_iter().map(Self::move_value_to_json).collect())
+            }
         }
     }
 
@@ -728,7 +1074,6 @@ impl<S: StateStore> RuntimeExecutor<S> {
 mod tests {
     use super::*;
     use crate::state::InMemoryStateStore;
-    use std::collections::BTreeMap;
 
     #[test]
     fn test_full_transfer() {
@@ -802,57 +1147,34 @@ mod tests {
     }
 
     #[test]
-    fn test_program_branch_and_jump() {
+    fn test_move_script_branch_and_return() {
         let store = InMemoryStateStore::new();
         let mut executor = RuntimeExecutor::new(store);
         let sender = Address::from("alice");
 
-        let instructions = vec![
-            Instruction::Const {
-                dst: 0,
-                value: ProgramValue::U64(10),
-            },
-            Instruction::Const {
-                dst: 1,
-                value: ProgramValue::U64(3),
-            },
-            Instruction::BinOp {
-                op: BinaryOp::Add,
-                dst: 2,
-                lhs: 0,
-                rhs: 1,
-            },
-            Instruction::Const {
-                dst: 3,
-                value: ProgramValue::U64(12),
-            },
-            Instruction::Cmp {
-                op: CompareOp::Gt,
-                dst: 4,
-                lhs: 2,
-                rhs: 3,
-            },
-            Instruction::JumpIf { cond: 4, pc: 8 },
-            Instruction::Const {
-                dst: 5,
-                value: ProgramValue::U64(0),
-            },
-            Instruction::Jump { pc: 9 },
-            Instruction::Const {
-                dst: 5,
-                value: ProgramValue::U64(1),
-            },
-            Instruction::StoreOutput {
-                key: "flag".to_string(),
-                src: 5,
-            },
-            Instruction::Halt {
-                success: true,
-                message: None,
-            },
-        ];
+        let script = MoveScriptTx {
+            code: vec![
+                Bytecode::CopyLoc(0),
+                Bytecode::CopyLoc(1),
+                Bytecode::Add,
+                Bytecode::LdU64(12),
+                Bytecode::Gt,
+                Bytecode::BrFalse(8),
+                Bytecode::LdU64(1),
+                Bytecode::Ret,
+                Bytecode::LdU64(0),
+                Bytecode::Ret,
+            ],
+            locals_sig: vec![SignatureToken::U64, SignatureToken::U64],
+            params_sig: vec![SignatureToken::U64, SignatureToken::U64],
+            return_sig: vec![SignatureToken::U64],
+            args: vec![MoveValue::U64(10), MoveValue::U64(3)],
+            type_args: vec![],
+            max_gas: 200,
+            input_objects: vec![],
+        };
 
-        let tx = Transaction::new_program(sender, instructions, BTreeMap::new(), None);
+        let tx = Transaction::new_move_script(sender, script);
         let ctx = ExecutionContext {
             executor_id: "solver1".to_string(),
             timestamp: 1000,
@@ -862,17 +1184,32 @@ mod tests {
         let output = executor.execute_transaction(&tx, &ctx).unwrap();
         assert!(output.success);
         let result = output.query_result.unwrap();
-        assert_eq!(result["flag"], serde_json::json!(1));
+        assert_eq!(result["returns"][0], serde_json::json!(1));
     }
 
     #[test]
-    fn test_program_step_limit() {
+    fn test_move_script_out_of_gas() {
         let store = InMemoryStateStore::new();
         let mut executor = RuntimeExecutor::new(store);
         let sender = Address::from("alice");
 
-        let instructions = vec![Instruction::Jump { pc: 0 }];
-        let tx = Transaction::new_program(sender, instructions, BTreeMap::new(), Some(5));
+        let script = MoveScriptTx {
+            code: vec![
+                Bytecode::LdTrue,
+                Bytecode::BrFalse(3),
+                Bytecode::Branch(0),
+                Bytecode::Ret,
+            ],
+            locals_sig: vec![],
+            params_sig: vec![],
+            return_sig: vec![],
+            args: vec![],
+            type_args: vec![],
+            max_gas: 8,
+            input_objects: vec![],
+        };
+
+        let tx = Transaction::new_move_script(sender, script);
         let ctx = ExecutionContext {
             executor_id: "solver1".to_string(),
             timestamp: 1000,
@@ -881,7 +1218,7 @@ mod tests {
 
         let err = executor.execute_transaction(&tx, &ctx).unwrap_err();
         assert!(
-            err.to_string().contains("step limit exceeded"),
+            err.to_string().contains("Out of gas"),
             "unexpected error: {}",
             err
         );

--- a/crates/setu-runtime/src/lib.rs
+++ b/crates/setu-runtime/src/lib.rs
@@ -18,6 +18,6 @@ pub use executor::{
 };
 pub use state::{InMemoryStateStore, StateStore};
 pub use transaction::{
-    BinaryOp, CompareOp, Instruction, ProgramTx, ProgramValue, QueryTx, Transaction,
-    TransactionType, TransferTx,
+    Bytecode, MoveScriptTx, MoveValue, QueryTx, SignatureToken, Transaction, TransactionType,
+    TransferTx, TypeTag,
 };

--- a/crates/setu-runtime/src/transaction.rs
+++ b/crates/setu-runtime/src/transaction.rs
@@ -2,7 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 use setu_types::{Address, ObjectId};
-use std::collections::BTreeMap;
 
 /// Transaction types
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -11,8 +10,8 @@ pub enum TransactionType {
     Transfer(TransferTx),
     /// Query transaction (read-only)
     Query(QueryTx),
-    /// Program transaction (small deterministic instruction set)
-    Program(ProgramTx),
+    /// Move-style script transaction (typed stack VM)
+    MoveScript(MoveScriptTx),
 }
 
 /// Simplified transaction structure
@@ -60,93 +59,86 @@ pub enum QueryType {
     OwnedObjects,
 }
 
-/// Program transaction payload.
-///
-/// This enables simple deterministic programmability without integrating a full VM.
+/// Move-style script payload for programmable execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProgramTx {
-    /// Program bytecode (instruction sequence)
-    pub instructions: Vec<Instruction>,
-    /// Named input values available via `LoadInput`
-    pub inputs: BTreeMap<String, ProgramValue>,
-    /// Optional execution step limit override
-    pub max_steps: Option<u64>,
+pub struct MoveScriptTx {
+    /// Bytecode instruction stream
+    pub code: Vec<Bytecode>,
+    /// Local variable signature table (slot types)
+    pub locals_sig: Vec<SignatureToken>,
+    /// Parameter signature (first N locals are parameters)
+    pub params_sig: Vec<SignatureToken>,
+    /// Return signature (stack shape expected at `Ret`)
+    pub return_sig: Vec<SignatureToken>,
+    /// Runtime argument values
+    pub args: Vec<MoveValue>,
+    /// Generic type arguments (reserved for phase-2+ features)
+    pub type_args: Vec<TypeTag>,
+    /// Gas budget for script execution
+    pub max_gas: u64,
+    /// Declared input objects this script can access
+    pub input_objects: Vec<ObjectId>,
 }
 
-/// Value type used by the program runtime.
+/// Runtime value type for the Move-style interpreter.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ProgramValue {
+pub enum MoveValue {
     U64(u64),
     Bool(bool),
+    Address(Address),
+    Vector(Vec<MoveValue>),
 }
 
-/// Arithmetic and bitwise binary operations.
+/// Type signatures used by verifier/interpreter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SignatureToken {
+    Bool,
+    U64,
+    Address,
+    Vector(Box<SignatureToken>),
+}
+
+/// Type tags for script generic arguments.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TypeTag {
+    Bool,
+    U64,
+    Address,
+    Vector(Box<TypeTag>),
+}
+
+/// Move-style phase-1 bytecode set.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum BinaryOp {
+pub enum Bytecode {
+    // Constants
+    LdU64(u64),
+    LdTrue,
+    LdFalse,
+    // Locals
+    CopyLoc(u8),
+    MoveLoc(u8),
+    StLoc(u8),
+    Pop,
+    // Arithmetic
     Add,
     Sub,
     Mul,
     Div,
     Mod,
-    BitAnd,
-    BitOr,
-    BitXor,
-}
-
-/// Comparison operations.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum CompareOp {
+    // Comparison
     Eq,
-    Ne,
+    Neq,
     Lt,
     Le,
     Gt,
     Ge,
-}
-
-/// Instruction set (10 opcodes total).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Instruction {
-    Nop,
-    Const {
-        dst: u8,
-        value: ProgramValue,
-    },
-    Mov {
-        dst: u8,
-        src: u8,
-    },
-    BinOp {
-        op: BinaryOp,
-        dst: u8,
-        lhs: u8,
-        rhs: u8,
-    },
-    Cmp {
-        op: CompareOp,
-        dst: u8,
-        lhs: u8,
-        rhs: u8,
-    },
-    LoadInput {
-        dst: u8,
-        key: String,
-    },
-    StoreOutput {
-        key: String,
-        src: u8,
-    },
-    Jump {
-        pc: u16,
-    },
-    JumpIf {
-        cond: u8,
-        pc: u16,
-    },
-    Halt {
-        success: bool,
-        message: Option<String>,
-    },
+    // Control flow
+    BrTrue(u16),
+    BrFalse(u16),
+    Branch(u16),
+    // Termination
+    Ret,
+    Abort { code: u64, message: Option<String> },
 }
 
 impl Transaction {
@@ -198,29 +190,20 @@ impl Transaction {
         }
     }
 
-    /// Create a new programmable transaction.
-    pub fn new_program(
-        sender: Address,
-        instructions: Vec<Instruction>,
-        inputs: BTreeMap<String, ProgramValue>,
-        max_steps: Option<u64>,
-    ) -> Self {
+    /// Create a new Move-style script transaction.
+    pub fn new_move_script(sender: Address, script: MoveScriptTx) -> Self {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
 
-        let id = format!("prog_{:x}", timestamp);
+        let id = format!("move_{:x}", timestamp);
 
         Self {
             id,
             sender,
-            tx_type: TransactionType::Program(ProgramTx {
-                instructions,
-                inputs,
-                max_steps,
-            }),
-            input_objects: vec![],
+            input_objects: script.input_objects.clone(),
+            tx_type: TransactionType::MoveScript(script),
             timestamp,
         }
     }


### PR DESCRIPTION
This PR introduces a tiny deterministic VM in Setu’s runtime layer as a stepping stone toward richer programmable execution.

## What Changed
- Added a new programmable transaction type:
    - TransactionType::Program
    - ProgramTx, ProgramValue, Instruction, BinaryOp, CompareOp
- Extended runtime dispatch to execute program transactions
- Implemented a compact interpreter (10 opcodes):
Nop, Const, Mov, BinOp, Cmp, LoadInput, StoreOutput, Jump, JumpIf, Halt
- Added determinism/safety guards:
    - register bounds checks
    - jump target validation
    - checked arithmetic
    - divide/mod-by-zero checks
    - program length cap
    - execution step limit (max_steps, with hard upper bound)
- Program execution currently returns outputs via `ExecutionOutput.query_result` and does not mutate object state.
- Re-exported new VM-related types from `lib.rs`.
- Added tests for:
 
    - branching/jump behavior
    - step limit enforcement
    - existing transfer flows still passing