### PR TITLE
fix: V1 testnet hardening — consensus liveness, ordering, networking, and deploy

### DIFF
--- a/consensus/src/engine.rs
+++ b/consensus/src/engine.rs
@@ -35,6 +35,26 @@ use crate::outcome_sink::OutcomeSink;
 use crate::validator_set::ValidatorSet;
 use crate::vlc::VLC;
 
+/// Completion queue entry: tracks CF with per-anchor persistence status.
+///
+/// Layer A (fix-post-restart-finality-stall-v2) defers CF broadcast and round
+/// advancement until after anchor persistence succeeds. This struct ensures
+/// only successfully-persisted anchors trigger broadcast.
+///
+/// See `docs/feat/fix-submit-event-batch-hole/design.md` for batch invariant
+/// protection.
+#[derive(Debug, Clone)]
+struct CompletionEntry {
+    /// The finalized ConsensusFrame waiting for broadcast
+    cf: ConsensusFrame,
+    /// AnchorId that produced this CF (tracks which anchor must persist first)
+    anchor_id: setu_types::AnchorId,
+    /// Expected round at finalize time (idempotency guard)
+    expected_round: Round,
+    /// Whether this anchor has been durably persisted
+    persisted: bool,
+}
+
 /// Messages exchanged between consensus components
 #[derive(Debug, Clone)]
 pub enum ConsensusMessage {
@@ -96,11 +116,16 @@ pub struct ConsensusEngine {
     /// round-drift window (see fix-post-restart-finality-stall-v2 design.md
     /// Layer A and review-log.md R3-VERIFY-4/8).
     ///
-    /// Each entry is `(ConsensusFrame, expected_round)` where `expected_round`
-    /// is the validator-set round captured at finalize time. The completion
-    /// step only advances the round if it still matches `expected_round`,
-    /// making the call idempotent under restart / duplicate dispatch.
-    pending_completions: Arc<Mutex<Vec<(ConsensusFrame, Round)>>>,
+    /// Each entry tracks a CF with its associated anchor_id, expected round, and
+    /// persistence status. The completion step only advances the round if it
+    /// still matches the entry's expected round, making the call idempotent
+    /// under restart / duplicate dispatch.
+    /// Only CFs for anchors that have been marked as persisted (via
+    /// `mark_anchor_persisted()`) are processed by `complete_pending_finalizations()`.
+    /// This protects against the batch-hole invariant violation where one anchor
+    /// fails to persist but its CF is still broadcast.
+    /// See `docs/feat/fix-submit-event-batch-hole/design.md` for details.
+    pending_completions: Arc<Mutex<Vec<CompletionEntry>>>,
     /// Broadcast channel for CF finalization notifications.
     /// Injected by caller (ConsensusValidator) via set_finalization_tx().
     /// Uses parking_lot::RwLock: broadcast::Sender::send() is synchronous.
@@ -342,12 +367,23 @@ impl ConsensusEngine {
     ///   peer-driven `receive_finalized_cf` for the same CF on a later tick),
     ///   we do not double-advance.
     pub async fn complete_pending_finalizations(&self) -> SetuResult<()> {
-        let pending: Vec<(ConsensusFrame, Round)> = {
+        // Collect persisted entries and remove them from queue
+        let pending: Vec<CompletionEntry> = {
             let mut q = self.pending_completions.lock().await;
-            std::mem::take(&mut *q)
+            let mut result = Vec::new();
+            q.retain(|e| {
+                if e.persisted {
+                    result.push(e.clone());
+                    false // remove from queue
+                } else {
+                    true // keep in queue
+                }
+            });
+            result
         };
-
-        for (cf, expected_round) in pending {
+        for entry in pending {
+            let cf = entry.cf;
+            let expected_round = entry.expected_round;
             let cf_id = cf.id.clone();
 
             // Internal channel (legacy local listeners).
@@ -405,6 +441,27 @@ impl ConsensusEngine {
     #[cfg(test)]
     pub async fn pending_completions_len(&self) -> usize {
         self.pending_completions.lock().await.len()
+    }
+
+    /// Mark an anchor as durably persisted for completion queue purposes.
+    ///
+    /// When an anchor persists successfully, call this to unblock its associated
+    /// CF from being broadcasted by `complete_pending_finalizations()`.
+    ///
+    /// This ensures Layer A invariant: no CF broadcast without prior anchor persist.
+    /// See `docs/feat/fix-submit-event-batch-hole/design.md` for details.
+    pub async fn mark_anchor_persisted(&self, anchor_id: &setu_types::AnchorId) {
+        {
+            let mut q = self.pending_completions.lock().await;
+            for entry in q.iter_mut() {
+                if entry.anchor_id == *anchor_id {
+                    entry.persisted = true;
+                }
+            }
+        }
+
+        let mut manager = self.consensus_manager.write().await;
+        manager.mark_anchor_persisted(anchor_id);
     }
 
     /// Mark finalized anchor events as no longer pending in the active DAG.
@@ -1311,7 +1368,7 @@ impl ConsensusEngine {
     /// 1. `dag_manager.update_min_depth(...)`
     /// 2. `mark_anchor_events_finalized_in_active_dag(...)`
     /// 3. push to `pending_persist_cfs` (durable index queue)
-    /// 4. push `(cf, expected_round)` to `pending_completions` (post-persist queue)
+    /// 4. push `CompletionEntry` to `pending_completions` (post-persist queue)
     ///
     /// Note: This method extracts data from manager before acquiring other locks
     /// to avoid potential deadlock from holding multiple write locks.
@@ -1347,7 +1404,12 @@ impl ConsensusEngine {
             };
             {
                 let mut q = self.pending_completions.lock().await;
-                q.push((cf.clone(), expected_round));
+                q.push(CompletionEntry {
+                    cf: cf.clone(),
+                    anchor_id: anchor.id.clone(),
+                    expected_round,
+                    persisted: false,
+                });
             }
 
             debug!(
@@ -1466,10 +1528,6 @@ impl ConsensusEngine {
     ///
     /// Call this after successfully storing the anchor to AnchorStore.
     /// This enables safe garbage collection of finalized CFs from memory.
-    pub async fn mark_anchor_persisted(&self, anchor_id: &str) {
-        let mut manager = self.consensus_manager.write().await;
-        manager.mark_anchor_persisted(anchor_id);
-    }
 
     /// Heartbeat attempt to create a CF for low-frequency events.
     ///
@@ -1739,6 +1797,7 @@ pub struct DagStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::broadcaster::MockBroadcaster;
     use setu_types::{Anchor, AnchorMerkleRoots, EventType, NodeInfo, ValidatorInfo};
     use setu_vlc::VectorClock;
     use std::collections::HashMap;
@@ -1813,6 +1872,9 @@ mod tests {
         assert!(anchor.is_some());
         // Layer A: round advance is deferred until complete_pending_finalizations.
         assert_eq!(engine.current_round().await, 0);
+        engine
+            .mark_anchor_persisted(&anchor.as_ref().unwrap().id)
+            .await;
         engine.complete_pending_finalizations().await.unwrap();
         assert_eq!(engine.current_round().await, 1);
 
@@ -1853,8 +1915,124 @@ mod tests {
         assert!(anchor.is_some());
         // Layer A: deferred until completion drains.
         assert_eq!(engine.current_round().await, 0);
+        engine
+            .mark_anchor_persisted(&anchor.as_ref().unwrap().id)
+            .await;
         engine.complete_pending_finalizations().await.unwrap();
         assert_eq!(engine.current_round().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_completion_does_not_broadcast_before_anchor_marked_persisted() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 1,
+            min_events_per_cf: 1,
+            max_events_per_cf: 1000,
+            cf_timeout_ms: 5000,
+            validator_count: 3,
+        };
+        let engine = ConsensusEngine::new(config, "v2".to_string(), create_validator_set());
+        let broadcaster = Arc::new(MockBroadcaster::new("v2".to_string(), 2));
+        engine.set_broadcaster(broadcaster.clone()).await;
+
+        let anchor = Anchor::new(
+            vec![],
+            VLCSnapshot::default(),
+            "state-root".to_string(),
+            None,
+            0,
+        );
+        let mut cf = ConsensusFrame::new(anchor, "v1".to_string());
+        cf.add_vote(Vote::new("v1".to_string(), cf.id.clone(), true));
+        cf.add_vote(Vote::new("v2".to_string(), cf.id.clone(), true));
+        cf.add_vote(Vote::new("v3".to_string(), cf.id.clone(), true));
+        cf.finalize();
+        let cf_id = cf.id.clone();
+
+        let (finalized, anchor) = engine.receive_finalized_cf(cf).await.unwrap();
+        let anchor = anchor.expect("finalized CF should return anchor");
+        assert!(finalized);
+
+        engine.complete_pending_finalizations().await.unwrap();
+        assert_eq!(engine.current_round().await, 0);
+        assert_eq!(engine.pending_completions_len().await, 1);
+        assert!(broadcaster.get_finalized_broadcasts().is_empty());
+
+        engine.mark_anchor_persisted(&anchor.id).await;
+        {
+            let manager = engine.consensus_manager.read().await;
+            assert!(manager.has_persisted_anchor_for_testing(&anchor.id));
+        }
+
+        engine.complete_pending_finalizations().await.unwrap();
+        assert_eq!(engine.current_round().await, 1);
+        assert_eq!(engine.pending_completions_len().await, 0);
+        assert_eq!(broadcaster.get_finalized_broadcasts(), vec![cf_id]);
+    }
+
+    #[tokio::test]
+    async fn test_partial_persisted_batch_only_completes_marked_anchor() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 1,
+            min_events_per_cf: 1,
+            max_events_per_cf: 1000,
+            cf_timeout_ms: 5000,
+            validator_count: 3,
+        };
+        let engine = ConsensusEngine::new(config, "v1".to_string(), create_validator_set());
+        let broadcaster = Arc::new(MockBroadcaster::new("v1".to_string(), 2));
+        engine.set_broadcaster(broadcaster.clone()).await;
+
+        let anchor1 = Anchor::new(
+            vec![],
+            VLCSnapshot::default(),
+            "state-root-1".to_string(),
+            None,
+            0,
+        );
+        let anchor2 = Anchor::new(
+            vec![],
+            VLCSnapshot::default(),
+            "state-root-2".to_string(),
+            Some(anchor1.id.clone()),
+            1,
+        );
+        let cf1 = ConsensusFrame::new(anchor1.clone(), "v1".to_string());
+        let cf2 = ConsensusFrame::new(anchor2.clone(), "v1".to_string());
+        {
+            let mut q = engine.pending_completions.lock().await;
+            q.push(CompletionEntry {
+                cf: cf1.clone(),
+                anchor_id: anchor1.id.clone(),
+                expected_round: 0,
+                persisted: false,
+            });
+            q.push(CompletionEntry {
+                cf: cf2.clone(),
+                anchor_id: anchor2.id.clone(),
+                expected_round: 0,
+                persisted: false,
+            });
+        }
+
+        engine.mark_anchor_persisted(&anchor1.id).await;
+        engine.complete_pending_finalizations().await.unwrap();
+        assert_eq!(broadcaster.get_finalized_broadcasts(), vec![cf1.id.clone()]);
+        assert_eq!(engine.pending_completions_len().await, 1);
+        assert_eq!(engine.current_round().await, 1);
+
+        engine.mark_anchor_persisted(&anchor2.id).await;
+        engine.complete_pending_finalizations().await.unwrap();
+        assert_eq!(
+            broadcaster.get_finalized_broadcasts(),
+            vec![cf1.id.clone(), cf2.id.clone()]
+        );
+        assert_eq!(engine.pending_completions_len().await, 0);
+        assert_eq!(
+            engine.current_round().await,
+            1,
+            "synthetic entries share expected_round=0, so the second completion is idempotent"
+        );
     }
 
     #[tokio::test]

--- a/consensus/src/engine.rs
+++ b/consensus/src/engine.rs
@@ -29,7 +29,7 @@ use tracing::{debug, info, warn};
 use crate::broadcaster::ConsensusBroadcaster;
 use crate::dag::Dag;
 use crate::dag_manager::{DagManager, DagManagerError};
-use crate::folder::ConsensusManager;
+use crate::folder::{CfLifecycleOutcome, ConsensusManager};
 use crate::liveness::Round;
 use crate::outcome_sink::OutcomeSink;
 use crate::validator_set::ValidatorSet;
@@ -792,9 +792,11 @@ impl ConsensusEngine {
                 debug!(cf_id = %frame.id, "Leader self-voted for CF");
 
                 // Check if this vote causes finalization (single-node mode)
-                if manager.check_finalization(&frame.id)
-                    && Self::manager_last_finalized_matches(&manager, &frame.id)
-                {
+                let outcome = manager.classify_finalization(&frame.id);
+                if let CfLifecycleOutcome::ApplyFailed { ref failure } = outcome {
+                    warn!(cf_id = %frame.id, ?failure, "CF dropped on apply failure (single-node path)");
+                }
+                if matches!(outcome, CfLifecycleOutcome::Finalized { .. }) {
                     // Immediately update depth floor so new events land above anchor_depth.
                     // This is critical: without it, events referencing old parents (e.g., genesis)
                     // would get a depth below anchor_depth, causing permanent InsufficientEvents.
@@ -1025,9 +1027,11 @@ impl ConsensusEngine {
 
             // Check if our vote caused finalization
             // (vote_for_cf adds vote but doesn't check finalization, so we check here)
-            let finalized = manager.check_finalization(&cf_id)
-                && Self::manager_last_finalized_matches(&manager, &cf_id);
-            if finalized {
+            let outcome = manager.classify_finalization(&cf_id);
+            if let CfLifecycleOutcome::ApplyFailed { ref failure } = outcome {
+                warn!(cf_id = %cf_id, ?failure, "CF dropped on apply failure (receive_cf path)");
+            }
+            if matches!(outcome, CfLifecycleOutcome::Finalized { .. }) {
                 return self.handle_finalization(&mut manager).await;
             }
         }
@@ -1090,9 +1094,11 @@ impl ConsensusEngine {
         manager.apply_cf_state_changes(&dag, &cf);
         drop(dag);
 
-        let finalized = manager.receive_finalized_cf(cf.clone())
-            && Self::manager_last_finalized_matches(&manager, &cf.id);
-        if finalized {
+        let outcome = manager.receive_finalized_cf(cf.clone());
+        if let CfLifecycleOutcome::ApplyFailed { ref failure } = outcome {
+            warn!(cf_id = %cf.id, ?failure, "CF dropped on apply failure (receive_finalized_cf path)");
+        }
+        if matches!(outcome, CfLifecycleOutcome::Finalized { .. }) {
             return self.handle_finalization(&mut manager).await;
         }
 
@@ -1426,16 +1432,6 @@ impl ConsensusEngine {
         Ok((true, finalized_anchor))
     }
 
-    fn manager_last_finalized_matches(
-        manager: &ConsensusManager,
-        cf_id: &str,
-    ) -> bool {
-        manager
-            .last_finalized_cf()
-            .map(|cf| cf.id == cf_id)
-            .unwrap_or(false)
-    }
-
     /// Receive a vote from another validator
     ///
     /// Returns (finalized, Option<Anchor>) - the anchor is returned when finalized
@@ -1461,10 +1457,12 @@ impl ConsensusEngine {
 
         let cf_id = vote.cf_id.clone();
         let mut manager = self.consensus_manager.write().await;
-        let finalized = manager.receive_vote(vote)
-            && Self::manager_last_finalized_matches(&manager, &cf_id);
+        let outcome = manager.receive_vote(vote);
+        if let CfLifecycleOutcome::ApplyFailed { ref failure } = outcome {
+            warn!(cf_id = %cf_id, ?failure, "CF dropped on apply failure (receive_vote path)");
+        }
 
-        if finalized {
+        if matches!(outcome, CfLifecycleOutcome::Finalized { .. }) {
             self.handle_finalization(&mut manager).await
         } else {
             Ok((false, None))
@@ -1524,10 +1522,37 @@ impl ConsensusEngine {
         manager.anchor_count()
     }
 
-    /// Mark an anchor as successfully persisted to storage
+    /// Periodic maintenance: time-out stale pending CFs.
     ///
-    /// Call this after successfully storing the anchor to AnchorStore.
-    /// This enables safe garbage collection of finalized CFs from memory.
+    /// BUG-010 follow-up: pending_builds is gated on `pending_cfs.is_empty()`,
+    /// so a pending CF that never reaches quorum (e.g. partial vote loss)
+    /// would block all future builds. Invoking `cleanup_timeout_cfs` on a
+    /// fixed cadence drops such CFs once `cf_timeout_ms` has elapsed,
+    /// unblocking the next build. Also clears any matching
+    /// `last_apply_failure` so the diagnostic does not outlive its CF.
+    ///
+    /// Idempotent: when there is nothing to time out, this is a cheap
+    /// no-op holding the manager write lock only briefly.
+    pub async fn run_periodic_maintenance(&self) {
+        let (removed, pending_builds_len, pending_cfs_len) = {
+            let mut manager = self.consensus_manager.write().await;
+            let removed = manager.cleanup_timeout_cfs();
+            (
+                removed,
+                manager.pending_builds_len(),
+                manager.pending_cfs_len(),
+            )
+        };
+        if removed > 0 {
+            tracing::debug!(
+                target: "consensus::diag::maintenance",
+                removed,
+                pending_builds_len,
+                pending_cfs_len,
+                "Periodic maintenance: timed-out CFs removed"
+            );
+        }
+    }
 
     /// Heartbeat attempt to create a CF for low-frequency events.
     ///
@@ -1566,9 +1591,11 @@ impl ConsensusEngine {
 
             let self_vote = manager.vote_for_cf(&frame.id, true, key_ref);
             if self_vote.is_some() {
-                if manager.check_finalization(&frame.id)
-                    && Self::manager_last_finalized_matches(&manager, &frame.id)
-                {
+                let outcome = manager.classify_finalization(&frame.id);
+                if let CfLifecycleOutcome::ApplyFailed { ref failure } = outcome {
+                    warn!(cf_id = %frame.id, ?failure, "CF dropped on apply failure (heartbeat path)");
+                }
+                if matches!(outcome, CfLifecycleOutcome::Finalized { .. }) {
                     let new_anchor_depth = manager.anchor_builder().anchor_depth();
                     self.dag_manager.update_min_depth(new_anchor_depth);
                     self.mark_anchor_events_finalized_in_active_dag(&frame.anchor)
@@ -2492,12 +2519,13 @@ mod tests {
 
             manager.receive_vote(vote1);
             manager.receive_vote(vote2);
-            let finalized = manager.receive_vote(vote3);
+            let outcome = manager.receive_vote(vote3);
 
             // Quorum is reached but apply fails → fail-closed.
             assert!(
-                !finalized,
-                "CF must NOT finalize when follower apply fails (BUG-010 fix)"
+                !outcome.is_finalized(),
+                "CF must NOT finalize when follower apply fails (BUG-010 fix): {:?}",
+                outcome
             );
             assert!(
                 !manager.is_finalized_cf(&cf.id),
@@ -2565,19 +2593,20 @@ mod tests {
         // Vote 1: approve (should not finalize yet)
         let vote1 = Vote::new("v1".to_string(), cf_id.clone(), true);
         let result1 = manager.receive_vote(vote1);
-        assert!(!result1, "Should not finalize with 1 approve vote");
+        assert!(!result1.is_terminal(), "Should not finalize with 1 approve vote: {:?}", result1);
 
         // Vote 2: reject (1 reject, not enough)
         let vote2 = Vote::new("v2".to_string(), cf_id.clone(), false);
         let result2 = manager.receive_vote(vote2);
-        assert!(!result2, "Should not reject with only 1 reject vote");
+        assert!(!result2.is_terminal(), "Should not reject with only 1 reject vote: {:?}", result2);
 
         // Vote 3: reject (2 rejects = 1/3+1, should reject)
         let vote3 = Vote::new("v3".to_string(), cf_id.clone(), false);
         let result3 = manager.receive_vote(vote3);
         assert!(
-            result3,
-            "Should reject with 2 reject votes (1/3+1 threshold)"
+            matches!(result3, crate::folder::CfLifecycleOutcome::Rejected { .. }),
+            "Should reject with 2 reject votes (1/3+1 threshold): {:?}",
+            result3
         );
 
         // Verify CF was removed from pending (can't directly access private field)
@@ -2687,8 +2716,9 @@ mod tests {
 
         // The vote processing should detect timeout and remove CF
         assert!(
-            result,
-            "Should return true when CF is removed due to timeout"
+            result.is_terminal(),
+            "Should return terminal outcome when CF is removed due to timeout: {:?}",
+            result
         );
     }
 
@@ -2739,7 +2769,7 @@ mod tests {
         manager.receive_vote(vote1);
         let rejected = manager.receive_vote(vote2);
 
-        assert!(rejected, "CF should be rejected with 2 reject votes");
+        assert!(rejected.is_terminal(), "CF should be rejected with 2 reject votes: {:?}", rejected);
 
         // Verify the CF is removed
         assert!(
@@ -2753,5 +2783,55 @@ mod tests {
 
         // For a true test of rollback, we'd need to use try_create_cf which actually
         // modifies anchor_builder state. This test verifies the reject path works.
+    }
+
+    /// BUG-010 follow-up / Test #8: `run_periodic_maintenance` removes a
+    /// timed-out pending CF so the Step 2 guard slot is freed.
+    #[tokio::test]
+    async fn followup_periodic_maintenance_logs_and_removes() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 10,
+            min_events_per_cf: 1,
+            max_events_per_cf: 100,
+            cf_timeout_ms: 50,
+            validator_count: 4,
+        };
+        let validator_set = create_validator_set();
+        let engine = ConsensusEngine::new(config, "v1".to_string(), validator_set);
+
+        let anchor = Anchor::with_merkle_roots(
+            vec![],
+            VLCSnapshot {
+                vector_clock: VectorClock::new(),
+                logical_time: 10,
+                physical_time: 0,
+            },
+            AnchorMerkleRoots {
+                events_root: [0u8; 32],
+                global_state_root: [0u8; 32],
+                anchor_chain_root: [0u8; 32],
+                subnet_roots: HashMap::new(),
+            },
+            None,
+            0,
+        );
+        let cf = ConsensusFrame::new(anchor, "v1".to_string());
+
+        {
+            let mut manager = engine.consensus_manager.write().await;
+            manager.receive_cf(cf);
+            assert_eq!(manager.pending_cfs_len(), 1);
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(80)).await;
+
+        engine.run_periodic_maintenance().await;
+
+        let manager = engine.consensus_manager.read().await;
+        assert_eq!(
+            manager.pending_cfs_len(),
+            0,
+            "run_periodic_maintenance must remove timed-out CFs"
+        );
     }
 }

--- a/consensus/src/engine.rs
+++ b/consensus/src/engine.rs
@@ -2409,7 +2409,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_follower_synchronizes_anchor_chain_root() {
+    async fn test_follower_rejects_cf_with_mismatched_global_state_root() {
+        // BUG-010 regression: previously check_finalization called
+        // anchor_builder.synchronize_finalized_anchor() on apply error and
+        // pushed the CF into finalized_cfs, advancing anchor_chain_root
+        // without any real state apply. The fix is fail-closed — apply
+        // errors now drop the CF and record last_apply_failure.
+        // See docs/feat/fix-bug010-finality-stall/design.md.
         use setu_types::{merkle::AnchorMerkleRoots, Anchor, EventType};
 
         let config = ConsensusConfig {
@@ -2419,15 +2425,11 @@ mod tests {
             ..Default::default()
         };
 
-        // Create leader engine
         let leader_engine =
             ConsensusEngine::new(config.clone(), "v1".to_string(), create_validator_set());
-
-        // Create follower engine
         let follower_engine =
             ConsensusEngine::new(config.clone(), "v2".to_string(), create_validator_set());
 
-        // Both start with same anchor_chain_root
         let initial_root = leader_engine.get_anchor_chain_root().await;
         assert_eq!(initial_root, [0u8; 32], "Initial root should be zero");
         assert_eq!(
@@ -2436,7 +2438,6 @@ mod tests {
             "Both nodes should start with same root"
         );
 
-        // Leader creates events and CF
         for i in 0..3 {
             let mut event = Event::new(
                 EventType::System,
@@ -2448,12 +2449,10 @@ mod tests {
                 },
                 "v1".to_string(),
             );
-            // Add execution result for state changes
             event.execution_result = Some(setu_types::ExecutionResult::success());
             let _ = leader_engine.add_event(event).await;
         }
 
-        // Try to create CF (needs enough VLC delta)
         {
             let mut vlc = leader_engine.vlc.write().await;
             for _ in 0..10 {
@@ -2462,11 +2461,11 @@ mod tests {
         }
 
         let _cf_opt = leader_engine.try_create_cf().await;
-        // CF creation might fail due to various reasons (min events, etc)
-        // For this test, we simulate a CF manually
 
-        // Create a CF with correct merkle roots
-        let correct_merkle_roots =
+        // Construct a CF with no events but a non-zero declared global_state_root.
+        // The follower's local apply (over zero events) cannot reproduce
+        // [2u8; 32], so RootMismatch must fire and the CF must be dropped.
+        let mismatched_roots =
             AnchorMerkleRoots::with_roots([1u8; 32], [2u8; 32], initial_root);
 
         let anchor = Anchor::with_merkle_roots(
@@ -2476,20 +2475,17 @@ mod tests {
                 logical_time: 10,
                 physical_time: 0,
             },
-            correct_merkle_roots,
+            mismatched_roots,
             None,
             0,
         );
 
         let cf = ConsensusFrame::new(anchor.clone(), "v1".to_string());
 
-        // Follower receives and finalizes CF
-        // Note: receive_cf will fail at various checks, but we can test the manager directly
         {
             let mut manager = follower_engine.consensus_manager.write().await;
             manager.receive_cf(cf.clone());
 
-            // Add votes to reach quorum (simulate 3 validators)
             let vote1 = Vote::new("v1".to_string(), cf.id.clone(), true);
             let vote2 = Vote::new("v2".to_string(), cf.id.clone(), true);
             let vote3 = Vote::new("v3".to_string(), cf.id.clone(), true);
@@ -2498,32 +2494,35 @@ mod tests {
             manager.receive_vote(vote2);
             let finalized = manager.receive_vote(vote3);
 
-            assert!(finalized, "CF should be finalized after quorum");
-
-            // Check that anchor_chain_root was updated
-            let updated_root = manager.anchor_builder().anchor_chain_root();
-            assert_ne!(
-                updated_root, initial_root,
-                "Anchor chain root should have been updated"
+            // Quorum is reached but apply fails → fail-closed.
+            assert!(
+                !finalized,
+                "CF must NOT finalize when follower apply fails (BUG-010 fix)"
+            );
+            assert!(
+                !manager.is_finalized_cf(&cf.id),
+                "Failed-apply CF must not be marked finalized"
             );
 
-            // Verify it matches the expected computation
-            let expected_root = {
-                let anchor_hash = anchor.compute_hash();
-                setu_types::hash_utils::chain_hash(&initial_root, &anchor_hash)
-            };
+            let failure = manager
+                .last_apply_failure()
+                .expect("last_apply_failure must be set on follower apply error");
+            assert_eq!(failure.cf_id, cf.id);
 
+            // anchor_chain_root MUST remain at initial_root: no spurious
+            // synchronize_finalized_anchor call. This is the core BUG-010
+            // invariant — apply failure must not pollute downstream state.
+            let post_root = manager.anchor_builder().anchor_chain_root();
             assert_eq!(
-                updated_root, expected_root,
-                "Anchor chain root should match expected chain hash"
+                post_root, initial_root,
+                "Anchor chain root must NOT advance when apply fails"
             );
         }
 
-        // Verify follower can now accept next CF with updated root
         let follower_root = follower_engine.get_anchor_chain_root().await;
-        assert_ne!(
+        assert_eq!(
             follower_root, initial_root,
-            "Follower root should be updated"
+            "Follower root must stay at initial when apply fails"
         );
     }
 

--- a/consensus/src/folder.rs
+++ b/consensus/src/folder.rs
@@ -87,6 +87,34 @@ impl DagFolder {
     }
 }
 
+/// Role classification for a CF that was discarded by `check_finalization`
+/// due to a state-apply error. Used by `ApplyFailure` for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyFailureRole {
+    /// Leader path: `commit_build` returned a non-`SnapshotMismatch` error.
+    LeaderCommitError,
+    /// Leader path: `commit_build` returned `SnapshotMismatch`, follower fallback
+    /// (`apply_follower_finalized_cf`) then returned an error.
+    LeaderFollowerFallback,
+    /// Follower path: deferred apply (`apply_follower_finalized_cf`) returned an error.
+    Follower,
+}
+
+/// Diagnostic record for a CF that reached quorum but failed state-apply.
+///
+/// Stored on `ConsensusManager` and overwritten on every new apply failure.
+/// The failed CF is NOT pushed into `finalized_cfs` and the engine does NOT
+/// persist/broadcast/advance-round for it. Events referenced by the failed CF
+/// remain in `dag.events` and will be re-folded into a future CF.
+#[derive(Debug, Clone)]
+pub struct ApplyFailure {
+    pub cf_id: String,
+    pub anchor_id: String,
+    pub anchor_depth: u64,
+    pub role: ApplyFailureRole,
+    pub reason: String,
+}
+
 /// ConsensusManager with integrated AnchorBuilder for Merkle tree management
 /// 
 /// This manager handles:
@@ -128,6 +156,10 @@ pub struct ConsensusManager {
     local_validator_id: String,
     /// Last build result for diagnostics
     last_build_result: Option<AnchorBuildResult>,
+    /// Most recent apply-failure observed by `check_finalization`.
+    /// Overwritten on each failure; cleared on construction.
+    /// Read by tests and operational diagnostics; never persisted or broadcast.
+    last_apply_failure: Option<ApplyFailure>,
 }
 
 impl ConsensusManager {
@@ -145,6 +177,7 @@ impl ConsensusManager {
             persisted_anchor_ids: std::collections::HashSet::new(),
             local_validator_id: validator_id,
             last_build_result: None,
+            last_apply_failure: None,
         }
     }
     
@@ -166,6 +199,7 @@ impl ConsensusManager {
             persisted_anchor_ids: std::collections::HashSet::new(),
             local_validator_id: validator_id,
             last_build_result: None,
+            last_apply_failure: None,
         }
     }
 
@@ -188,6 +222,19 @@ impl ConsensusManager {
         dag: &Dag,
         vlc: &VLC,
     ) -> Option<ConsensusFrame> {
+        // BUG-010 Step 2: enforce one open pending_build per local proposer.
+        // current_round only advances after the local proposer's own CF finalizes,
+        // so any entry in pending_builds belongs to the current round / current
+        // anchor depth. Creating a second CF here would prepare against the same
+        // pre-state base and inevitably hit SnapshotMismatch on the loser CF.
+        if !self.pending_builds.is_empty() {
+            tracing::debug!(
+                pending_builds = self.pending_builds.len(),
+                "try_create_cf skipped: pending_build already open for current round"
+            );
+            return None;
+        }
+
         // D1: compute the set of event-ids already referenced by in-flight CFs
         // (leader's pending_builds + follower's pending_cf_events). Passed to
         // prepare_build so the pending-status selection excludes them.
@@ -278,6 +325,13 @@ impl ConsensusManager {
     #[cfg(test)]
     pub fn pending_counts_for_testing(&self) -> (usize, usize) {
         (self.pending_cfs.len(), self.pending_cf_events.len())
+    }
+
+    /// Number of open pending_builds (test-only).
+    /// Used by BUG-010 regression tests to verify the Step 2 guard contract.
+    #[cfg(test)]
+    pub fn pending_builds_len_for_testing(&self) -> usize {
+        self.pending_builds.len()
     }
 
     pub fn receive_cf(&mut self, cf: ConsensusFrame) {
@@ -418,75 +472,125 @@ impl ConsensusManager {
             Some(CFDecision::Finalize) => {
                 if let Some(mut cf) = self.pending_cfs.remove(cf_id) {
                     cf.finalize();
-                    
-                    // Check if this is our CF (we have a pending_build for it)
-                    if let Some(pending_build) = self.pending_builds.remove(cf_id) {
-                        // Leader path: commit the pending build
-                        // Clean up stored events (Leader uses pending_build's events)
-                        self.pending_cf_events.remove(cf_id);
-                        tracing::info!(cf_id = %cf_id, "Leader path: committing pending build");
-                        match self.anchor_builder.commit_build(pending_build.clone()) {
-                            Ok(state_summary) => {
-                                tracing::info!(
-                                    cf_id = %cf_id,
-                                    total_events = state_summary.total_events,
-                                    total_changes = state_summary.total_changes,
-                                    conflicted = state_summary.conflicted_events.len(),
-                                    "Leader path: commit_build succeeded"
-                                );
-                                // Store result for diagnostics
-                                self.last_build_result = Some(AnchorBuildResult {
-                                    anchor: cf.anchor.clone(),
-                                    state_summary,
-                                    routed_events: pending_build.routed_events,
-                                });
-                            }
-                            Err(AnchorBuildError::SnapshotMismatch { .. }) => {
-                                // Another CF was committed first - use Follower path
-                                tracing::warn!(cf_id = %cf_id, "Snapshot mismatch during commit, falling back to follower path");
-                                let events = pending_build.all_events();
-                                if let Err(e) = self.anchor_builder.apply_follower_finalized_cf(&events, &cf) {
-                                    tracing::error!(cf_id = %cf_id, error = %e, "Follower fallback failed, syncing metadata only");
-                                    self.anchor_builder.synchronize_finalized_anchor(&cf.anchor);
+                    let anchor_id = cf.anchor.id.clone();
+                    let anchor_depth = cf.anchor.depth;
+
+                    // Outcome of the apply attempt. Only Ok(()) pushes the CF into
+                    // finalized_cfs; Err(_) discards the CF, records the failure, and
+                    // causes check_finalization to return false so the engine's
+                    // existing `manager_last_finalized_matches` guard skips persist/
+                    // broadcast/round-advance. Events stay in dag.events for re-folding.
+                    // See docs/feat/fix-bug010-finality-stall/design.md.
+                    let apply_outcome: Result<(), ApplyFailure> =
+                        if let Some(pending_build) = self.pending_builds.remove(cf_id) {
+                            // Leader path: commit the pending build
+                            // Clean up stored events (Leader uses pending_build's events)
+                            self.pending_cf_events.remove(cf_id);
+                            tracing::info!(cf_id = %cf_id, "Leader path: committing pending build");
+                            match self.anchor_builder.commit_build(pending_build.clone()) {
+                                Ok(state_summary) => {
+                                    tracing::info!(
+                                        cf_id = %cf_id,
+                                        total_events = state_summary.total_events,
+                                        total_changes = state_summary.total_changes,
+                                        conflicted = state_summary.conflicted_events.len(),
+                                        "Leader path: commit_build succeeded"
+                                    );
+                                    // Store result for diagnostics
+                                    self.last_build_result = Some(AnchorBuildResult {
+                                        anchor: cf.anchor.clone(),
+                                        state_summary,
+                                        routed_events: pending_build.routed_events,
+                                    });
+                                    Ok(())
+                                }
+                                Err(AnchorBuildError::SnapshotMismatch { .. }) => {
+                                    // Another CF was committed first - use Follower path
+                                    tracing::warn!(cf_id = %cf_id, "Snapshot mismatch during commit, falling back to follower path");
+                                    let events = pending_build.all_events();
+                                    match self.anchor_builder.apply_follower_finalized_cf(&events, &cf) {
+                                        Ok(_) => Ok(()),
+                                        Err(e) => {
+                                            tracing::error!(
+                                                cf_id = %cf_id, error = %e,
+                                                "Follower fallback failed; discarding CF (BUG-010 fail-closed)"
+                                            );
+                                            Err(ApplyFailure {
+                                                cf_id: cf_id.to_string(),
+                                                anchor_id: anchor_id.clone(),
+                                                anchor_depth,
+                                                role: ApplyFailureRole::LeaderFollowerFallback,
+                                                reason: e.to_string(),
+                                            })
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    // Other error - discard CF (BUG-010 fail-closed)
+                                    tracing::error!(
+                                        cf_id = %cf_id, error = %e,
+                                        "commit_build failed; discarding CF (BUG-010 fail-closed)"
+                                    );
+                                    Err(ApplyFailure {
+                                        cf_id: cf_id.to_string(),
+                                        anchor_id: anchor_id.clone(),
+                                        anchor_depth,
+                                        role: ApplyFailureRole::LeaderCommitError,
+                                        reason: e.to_string(),
+                                            })
                                 }
                             }
-                            Err(e) => {
-                                // Other error - sync metadata at minimum
-                                tracing::error!(cf_id = %cf_id, error = %e, "Commit failed, syncing metadata only");
-                                self.anchor_builder.synchronize_finalized_anchor(&cf.anchor);
+                        } else {
+                            // Follower path: apply state at finalization time (deferred apply).
+                            // Events were stored in pending_cf_events when the CF arrived.
+                            // Applying here (not on arrival) guarantees correct ordering:
+                            // CFs finalize in Leader commit order, so the write GSM base
+                            // state always matches what the Leader computed against.
+                            let events = self.pending_cf_events.remove(cf_id).unwrap_or_default();
+                            tracing::info!(cf_id = %cf_id, event_count = events.len(), "Follower path: applying deferred state");
+                            match self.anchor_builder.apply_follower_finalized_cf(&events, &cf) {
+                                Ok(state_summary) => {
+                                    tracing::info!(
+                                        cf_id = %cf_id,
+                                        total_events = state_summary.total_events,
+                                        total_changes = state_summary.total_changes,
+                                        "Follower path: state applied and committed"
+                                    );
+                                    Ok(())
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        cf_id = %cf_id, error = %e,
+                                        "Follower deferred apply failed; discarding CF (BUG-010 fail-closed)"
+                                    );
+                                    Err(ApplyFailure {
+                                        cf_id: cf_id.to_string(),
+                                        anchor_id: anchor_id.clone(),
+                                        anchor_depth,
+                                        role: ApplyFailureRole::Follower,
+                                        reason: e.to_string(),
+                                    })
+                                }
                             }
+                        };
+
+                    match apply_outcome {
+                        Ok(()) => {
+                            self.last_apply_failure = None;
+                            self.finalized_cfs.push(cf);
+                            self.gc_finalized_cfs();
+                            return true;
                         }
-                    } else {
-                        // Follower path: apply state at finalization time (deferred apply).
-                        // Events were stored in pending_cf_events when the CF arrived.
-                        // Applying here (not on arrival) guarantees correct ordering:
-                        // CFs finalize in Leader commit order, so the write GSM base
-                        // state always matches what the Leader computed against.
-                        let events = self.pending_cf_events.remove(cf_id).unwrap_or_default();
-                        tracing::info!(cf_id = %cf_id, event_count = events.len(), "Follower path: applying deferred state");
-                        match self.anchor_builder.apply_follower_finalized_cf(&events, &cf) {
-                            Ok(state_summary) => {
-                                tracing::info!(
-                                    cf_id = %cf_id,
-                                    total_events = state_summary.total_events,
-                                    total_changes = state_summary.total_changes,
-                                    "Follower path: state applied and committed"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::error!(cf_id = %cf_id, error = %e,
-                                    "Follower deferred apply failed, syncing metadata only");
-                                self.anchor_builder.synchronize_finalized_anchor(&cf.anchor);
-                            }
+                        Err(failure) => {
+                            // CF discarded; do NOT push to finalized_cfs, do NOT call
+                            // synchronize_finalized_anchor. last_finalized_cf() therefore
+                            // does not advance, and the engine's
+                            // manager_last_finalized_matches guard correctly skips
+                            // persist/broadcast/round-advance for this cf_id.
+                            self.last_apply_failure = Some(failure);
+                            return false;
                         }
                     }
-                    
-                    self.finalized_cfs.push(cf);
-                    
-                    // Trigger safe garbage collection
-                    self.gc_finalized_cfs();
-                    
-                    return true;
                 }
             }
             Some(CFDecision::Reject) | Some(CFDecision::Timeout) => {
@@ -664,6 +768,13 @@ impl ConsensusManager {
     pub fn last_build_result(&self) -> Option<&AnchorBuildResult> {
         self.last_build_result.as_ref()
     }
+
+    /// Get the most recent apply-failure observed by `check_finalization`.
+    /// Returns `None` if no apply failure has occurred since construction or the
+    /// last successful finalization.
+    pub fn last_apply_failure(&self) -> Option<&ApplyFailure> {
+        self.last_apply_failure.as_ref()
+    }
     
     /// Get a subnet's current state root
     pub fn get_subnet_root(&self, subnet_id: &setu_types::SubnetId) -> Option<[u8; 32]> {
@@ -747,7 +858,7 @@ impl ConsensusManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use setu_types::{Event, EventType, VLCSnapshot};
+    use setu_types::{Event, EventType, VLCSnapshot, AnchorMerkleRoots};
 
     fn create_vlc(node_id: &str, time: u64) -> VLC {
         let mut vlc = VLC::new(node_id.to_string());
@@ -874,5 +985,175 @@ mod tests {
         assert!(manager.receive_finalized_cf(finalized_cf));
         assert!(manager.is_finalized_cf(&cf_id));
         assert!(!manager.receive_finalized_cf(duplicate_finalized_cf));
+    }
+
+    // ------------------------------------------------------------------
+    // BUG-010 regression tests.
+    // See docs/feat/fix-bug010-finality-stall/design.md.
+    // ------------------------------------------------------------------
+
+    /// Step 2 guard: try_create_cf must skip when a pending_build is already
+    /// open for the current round (one proposer => one in-flight CF).
+    #[test]
+    fn bug010_try_create_cf_skips_when_pending_build_open() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            validator_count: 3,
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(10);
+
+        let first = manager.try_create_cf(&dag, &vlc);
+        assert!(first.is_some(), "first try_create_cf should produce a CF");
+
+        // Second call must be skipped by the Step 2 guard because the first
+        // CF's pending_build is still open (not yet finalized).
+        let second = manager.try_create_cf(&dag, &vlc);
+        assert!(
+            second.is_none(),
+            "second try_create_cf must return None while pending_build is open"
+        );
+    }
+
+    /// Step 2 guard: once the pending_build is drained (CF finalizes
+    /// successfully), the guard no longer blocks new CF creation.
+    /// We assert the guard's direct precondition (pending_builds emptiness)
+    /// rather than driving a second try_create_cf, which depends on unrelated
+    /// vlc/delta thresholds and dag growth.
+    #[test]
+    fn bug010_pending_builds_drained_after_successful_finalize() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            validator_count: 1, // self-quorum for instant finalize
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(10);
+
+        let cf = manager.try_create_cf(&dag, &vlc).expect("first CF");
+        let cf_id = cf.id.clone();
+        assert_eq!(
+            manager.pending_builds_len_for_testing(),
+            1,
+            "pending_build must be open after try_create_cf"
+        );
+
+        manager.vote_for_cf(&cf_id, true, None);
+        assert!(manager.check_finalization(&cf_id), "CF should finalize");
+
+        assert_eq!(
+            manager.pending_builds_len_for_testing(),
+            0,
+            "pending_builds must be empty after successful finalize \
+             (Step 2 guard would otherwise permanently block new CFs)"
+        );
+    }
+
+    /// Step 1 fail-closed: a follower-path CF whose declared global_state_root
+    /// does NOT match the locally-computed root must be DROPPED:
+    ///   - check_finalization returns false
+    ///   - the CF is NOT pushed into finalized_cfs
+    ///   - last_apply_failure records the Follower role
+    ///   - last_finalized_cf remains unchanged (no spurious advance)
+    ///
+    /// This is the core BUG-010 regression: previously the error branch called
+    /// synchronize_finalized_anchor + finalized_cfs.push, lying to the engine
+    /// that the CF had finalized despite no state apply.
+    #[test]
+    fn bug010_follower_apply_failure_drops_cf_and_does_not_advance() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            validator_count: 3,
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(3);
+
+        // Build a foreign-looking CF directly (NOT via try_create_cf), so
+        // pending_builds stays empty and check_finalization takes the
+        // follower deferred-apply path.
+        let event_ids: Vec<_> = dag.all_events().map(|e| e.id.clone()).collect();
+        assert_eq!(event_ids.len(), 3);
+
+        let bad_roots = AnchorMerkleRoots {
+            events_root: [0u8; 32],
+            global_state_root: [0xFFu8; 32], // intentionally wrong
+            anchor_chain_root: [0u8; 32],
+            subnet_roots: Default::default(),
+        };
+        let anchor = Anchor::with_merkle_roots(
+            event_ids,
+            vlc.snapshot(),
+            bad_roots,
+            None,
+            0,
+        );
+        let cf = ConsensusFrame::new(anchor, "v2".to_string());
+        let cf_id = cf.id.clone();
+
+        // Receive the CF and inject its events into pending_cf_events so the
+        // follower deferred-apply path has work to do.
+        manager.receive_cf(cf.clone());
+        assert!(manager.apply_cf_state_changes(&dag, &cf));
+
+        // Drive to quorum: self vote + two foreign votes via receive_finalized_cf.
+        manager.vote_for_cf(&cf_id, true, None);
+        let mut quorum_cf = cf.clone();
+        quorum_cf.add_vote(Vote::new("v1".to_string(), cf_id.clone(), true));
+        quorum_cf.add_vote(Vote::new("v2".to_string(), cf_id.clone(), true));
+        quorum_cf.add_vote(Vote::new("v3".to_string(), cf_id.clone(), true));
+
+        let finalized_ok = manager.receive_finalized_cf(quorum_cf);
+
+        // The CF must be REJECTED (apply failed → fail-closed).
+        assert!(
+            !finalized_ok,
+            "receive_finalized_cf must return false when follower apply fails"
+        );
+        assert!(
+            !manager.is_finalized_cf(&cf_id),
+            "failed-apply CF must NOT be marked finalized"
+        );
+        assert!(
+            manager.last_finalized_cf().is_none(),
+            "last_finalized_cf must stay None (no spurious advance)"
+        );
+
+        let failure = manager
+            .last_apply_failure()
+            .expect("last_apply_failure must be populated on follower apply error");
+        assert_eq!(failure.cf_id, cf_id);
+        assert_eq!(failure.role, ApplyFailureRole::Follower);
+        assert!(
+            !failure.reason.is_empty(),
+            "failure.reason should carry the underlying error text"
+        );
+    }
+
+    /// Regression: a CF that applies cleanly on the leader path still finalizes
+    /// and clears any prior last_apply_failure record.
+    #[test]
+    fn bug010_successful_apply_finalizes_and_clears_failure() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            validator_count: 1, // self-quorum
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(10);
+
+        let cf = manager.try_create_cf(&dag, &vlc).expect("CF");
+        let cf_id = cf.id.clone();
+        manager.vote_for_cf(&cf_id, true, None);
+        assert!(manager.check_finalization(&cf_id));
+
+        assert!(manager.is_finalized_cf(&cf_id));
+        assert!(manager.last_apply_failure().is_none());
+        assert!(manager.last_finalized_cf().is_some());
     }
 }

--- a/consensus/src/folder.rs
+++ b/consensus/src/folder.rs
@@ -115,6 +115,46 @@ pub struct ApplyFailure {
     pub reason: String,
 }
 
+/// Post-apply observable outcome of a CF's lifecycle.
+///
+/// Distinct from the private `CFDecision` enum (pre-apply quorum status).
+/// `classify_finalization` collapses (CFDecision × apply_outcome) into this
+/// single typed value so callers cannot forget the apply check (BUG-010 class).
+///
+/// Engine call sites match on this enum directly; only `Finalized` triggers
+/// persist / broadcast / round-advance.
+#[derive(Debug, Clone)]
+pub enum CfLifecycleOutcome {
+    /// CF not yet at quorum, or no decision reached (still pending).
+    Pending,
+    /// CF reached quorum AND apply succeeded. `cf_id` is the finalized CF id.
+    /// Engine looks up the full CF via `manager.last_finalized_cf()`.
+    Finalized { cf_id: String },
+    /// CF reached quorum but apply failed; CF dropped, events stay in DAG.
+    ApplyFailed { failure: ApplyFailure },
+    /// CF rejected by vote tally; removed from pending_cfs.
+    Rejected { cf_id: String },
+    /// CF exceeded timeout; removed from pending_cfs.
+    TimedOut { cf_id: String },
+}
+
+impl CfLifecycleOutcome {
+    /// True iff the CF reached a terminal state (Finalized, ApplyFailed,
+    /// Rejected, or TimedOut) and was removed from `pending_cfs`.
+    ///
+    /// Used by legacy tests that previously called `check_finalization`
+    /// and treated "removed from pending" as a boolean signal. New engine
+    /// code should `match` on the variant directly.
+    pub fn is_terminal(&self) -> bool {
+        !matches!(self, CfLifecycleOutcome::Pending)
+    }
+
+    /// True iff the CF was finalized AND state apply succeeded.
+    pub fn is_finalized(&self) -> bool {
+        matches!(self, CfLifecycleOutcome::Finalized { .. })
+    }
+}
+
 /// ConsensusManager with integrated AnchorBuilder for Merkle tree management
 /// 
 /// This manager handles:
@@ -217,6 +257,31 @@ impl ConsensusManager {
     /// 1. Calls prepare_build() which computes but doesn't modify state
     /// 2. Stores PendingAnchorBuild for later commit on finalization
     /// 3. Creates ConsensusFrame for voting
+    /// Single source of truth for the BUG-010 Step 2 invariant:
+    /// "at most one open `pending_build` per local proposer at any time".
+    /// Called from BOTH `try_create_cf` and `try_create_cf_heartbeat` so the
+    /// guard cannot be bypassed via the heartbeat path.
+    fn can_start_new_pending_build(&self) -> bool {
+        self.pending_builds.is_empty()
+    }
+
+    /// Emit the BUG-010 follow-up diagnostic trace at `prepare_build` entry.
+    /// Carries the split counts that distinguish leader multi-build from
+    /// follower-apply-shift triggers. Logged at `debug!` so production cost
+    /// is zero unless `RUST_LOG=consensus::diag=debug` is set.
+    fn trace_prepare_build_entry(&self, path: &'static str, dag: &Dag) {
+        tracing::debug!(
+            target: "consensus::diag::prepare_build_entry",
+            path,
+            base_anchor_depth = self.anchor_builder.anchor_depth(),
+            base_anchor_chain_root = %hex::encode(self.anchor_builder.anchor_chain_root()),
+            pending_builds_count = self.pending_builds.len(),
+            pending_cf_events_count = self.pending_cf_events.len(),
+            dag_max_depth = dag.max_depth(),
+            "prepare base snapshot",
+        );
+    }
+
     pub fn try_create_cf(
         &mut self,
         dag: &Dag,
@@ -227,7 +292,7 @@ impl ConsensusManager {
         // so any entry in pending_builds belongs to the current round / current
         // anchor depth. Creating a second CF here would prepare against the same
         // pre-state base and inevitably hit SnapshotMismatch on the loser CF.
-        if !self.pending_builds.is_empty() {
+        if !self.can_start_new_pending_build() {
             tracing::debug!(
                 pending_builds = self.pending_builds.len(),
                 "try_create_cf skipped: pending_build already open for current round"
@@ -239,6 +304,7 @@ impl ConsensusManager {
         // (leader's pending_builds + follower's pending_cf_events). Passed to
         // prepare_build so the pending-status selection excludes them.
         let in_flight = self.collect_in_flight_event_ids();
+        self.trace_prepare_build_entry("normal", dag);
         // Use AnchorBuilder.prepare_build (deferred commit mode)
         match self.anchor_builder.prepare_build(dag, vlc, &in_flight) {
             Ok(pending_build) => self.finalize_pending_build(pending_build),
@@ -284,6 +350,20 @@ impl ConsensusManager {
         vlc: &VLC,
         heartbeat_interval: std::time::Duration,
     ) -> Option<ConsensusFrame> {
+        // BUG-010 follow-up: heartbeat must obey the same Step 2 invariant as
+        // the normal path. Without this guard the 5s heartbeat tick could open
+        // a second pending_build while a normal-path build is still open,
+        // reintroducing parallel CFs from one base.
+        if !self.can_start_new_pending_build() {
+            tracing::debug!(
+                target: "consensus::diag::prepare_build_blocked",
+                path = "heartbeat",
+                pending_builds_count = self.pending_builds.len(),
+                "heartbeat suppressed: pending_build already open",
+            );
+            return None;
+        }
+        self.trace_prepare_build_entry("heartbeat", dag);
         let in_flight = self.collect_in_flight_event_ids();
         match self.anchor_builder.prepare_build_heartbeat(dag, vlc, heartbeat_interval, &in_flight) {
             Ok(pending_build) => self.finalize_pending_build(pending_build),
@@ -334,6 +414,17 @@ impl ConsensusManager {
         self.pending_builds.len()
     }
 
+    /// Production accessor: number of open pending_builds.
+    /// Used by `ConsensusEngine::run_periodic_maintenance` diagnostics.
+    pub fn pending_builds_len(&self) -> usize {
+        self.pending_builds.len()
+    }
+
+    /// Production accessor: number of pending (not-yet-finalized) CFs.
+    pub fn pending_cfs_len(&self) -> usize {
+        self.pending_cfs.len()
+    }
+
     pub fn receive_cf(&mut self, cf: ConsensusFrame) {
         let cf_id = cf.id.clone();
         if !self.pending_cfs.contains_key(&cf_id) {
@@ -352,10 +443,10 @@ impl ConsensusManager {
         }
     }
 
-    pub fn receive_finalized_cf(&mut self, cf: ConsensusFrame) -> bool {
+    pub fn receive_finalized_cf(&mut self, cf: ConsensusFrame) -> CfLifecycleOutcome {
         let cf_id = cf.id.clone();
         if self.is_finalized_cf(&cf_id) {
-            return false;
+            return CfLifecycleOutcome::Pending;
         }
 
         if let Some(existing) = self.pending_cfs.get_mut(&cf_id) {
@@ -368,7 +459,7 @@ impl ConsensusManager {
             self.receive_cf(cf);
         }
 
-        self.check_finalization(&cf_id)
+        self.classify_finalization(&cf_id)
     }
 
     /// Vote for a ConsensusFrame
@@ -413,43 +504,47 @@ impl ConsensusManager {
 
     /// Receive a vote from another validator
     /// 
-    /// Returns true if this vote changes the CF lifecycle by finalizing,
-    /// rejecting, or timing out the pending CF. Duplicate votes from the same
-    /// validator are ignored (idempotent). Engine callers must verify the
-    /// target CF is actually the last finalized CF before running finalization
-    /// side effects such as broadcast, persistence, or round advance.
-    pub fn receive_vote(&mut self, vote: Vote) -> bool {
+    /// Returns the resulting `CfLifecycleOutcome` for the vote's target CF.
+    /// Duplicate votes from the same validator are ignored (idempotent) and
+    /// yield `Pending`. Engine callers should match on the outcome and only
+    /// trigger finalization side effects (broadcast, persistence, round
+    /// advance) on `CfLifecycleOutcome::Finalized { cf_id }` whose `cf_id`
+    /// matches the vote's target.
+    pub fn receive_vote(&mut self, vote: Vote) -> CfLifecycleOutcome {
         let cf_id = vote.cf_id.clone();
         let voter_id = vote.validator_id.clone();
         
         if let Some(cf) = self.pending_cfs.get_mut(&cf_id) {
             // Skip if this validator already voted (idempotency)
             if cf.votes.contains_key(&voter_id) {
-                return false;
+                return CfLifecycleOutcome::Pending;
             }
             cf.add_vote(vote);
         } else {
             // CF not yet received — buffer the vote for later replay.
             // In P2P networks, votes can arrive before their CF proposal.
             self.buffered_votes.entry(cf_id.clone()).or_default().push(vote);
-            return false;
+            return CfLifecycleOutcome::Pending;
         }
-        self.check_finalization(&cf_id)
+        self.classify_finalization(&cf_id)
     }
 
-    /// Check if a CF has reached quorum (finalize), rejection threshold (reject), or timeout
-    /// 
-    /// This is called after adding a vote to check if finalization/rejection should occur.
-    /// Public because engine.receive_cf() needs to check after vote_for_cf().
-    /// 
-    /// Returns true if CF was finalized or rejected/timed out (removed from pending).
-    /// Engine callers must check the last finalized CF id before treating this
-    /// as a finalized outcome.
-    pub fn check_finalization(&mut self, cf_id: &str) -> bool {
+    /// Classify a CF's post-apply lifecycle outcome.
+    ///
+    /// Replaces the old `check_finalization() -> bool` API. Returns a typed
+    /// `CfLifecycleOutcome` so callers cannot forget the apply check (root
+    /// cause of BUG-010). Removes the CF from `pending_cfs` on Finalize /
+    /// Reject / Timeout / ApplyFailed; idempotent for `Pending`.
+    ///
+    /// On `Finalized { cf_id }` the CF has been pushed into `finalized_cfs`
+    /// and `last_finalized_cf().id == cf_id` is guaranteed.
+    /// On `ApplyFailed { failure }` the CF was discarded; events stay in
+    /// `dag.events` and `last_finalized_cf()` does NOT advance.
+    pub fn classify_finalization(&mut self, cf_id: &str) -> CfLifecycleOutcome {
         let decision = {
             let cf = match self.pending_cfs.get(cf_id) {
                 Some(cf) => cf,
-                None => return false,
+                None => return CfLifecycleOutcome::Pending,
             };
             
             // Check if CF should be finalized (2/3+1 approve)
@@ -579,33 +674,39 @@ impl ConsensusManager {
                             self.last_apply_failure = None;
                             self.finalized_cfs.push(cf);
                             self.gc_finalized_cfs();
-                            return true;
+                            return CfLifecycleOutcome::Finalized { cf_id: cf_id.to_string() };
                         }
                         Err(failure) => {
                             // CF discarded; do NOT push to finalized_cfs, do NOT call
                             // synchronize_finalized_anchor. last_finalized_cf() therefore
-                            // does not advance, and the engine's
-                            // manager_last_finalized_matches guard correctly skips
-                            // persist/broadcast/round-advance for this cf_id.
-                            self.last_apply_failure = Some(failure);
-                            return false;
+                            // does not advance, and the engine's typed `match` on
+                            // CfLifecycleOutcome correctly skips persist/broadcast/
+                            // round-advance for this cf_id.
+                            self.last_apply_failure = Some(failure.clone());
+                            return CfLifecycleOutcome::ApplyFailed { failure };
                         }
                     }
                 }
             }
-            Some(CFDecision::Reject) | Some(CFDecision::Timeout) => {
-                // Remove rejected/timeout CF from pending
+            Some(CFDecision::Reject) => {
                 if let Some(mut cf) = self.pending_cfs.remove(cf_id) {
-                    // Simply discard the pending_build and stored events (no rollback needed!)
                     self.pending_builds.remove(cf_id);
                     self.pending_cf_events.remove(cf_id);
                     cf.reject();
-                    return true;
+                    return CfLifecycleOutcome::Rejected { cf_id: cf_id.to_string() };
+                }
+            }
+            Some(CFDecision::Timeout) => {
+                if let Some(mut cf) = self.pending_cfs.remove(cf_id) {
+                    self.pending_builds.remove(cf_id);
+                    self.pending_cf_events.remove(cf_id);
+                    cf.reject();
+                    return CfLifecycleOutcome::TimedOut { cf_id: cf_id.to_string() };
                 }
             }
             None => {}
         }
-        false
+        CfLifecycleOutcome::Pending
     }
     
     /// Mark an anchor as persisted to storage
@@ -673,12 +774,22 @@ impl ConsensusManager {
         
         let count = timeout_ids.len();
         for id in timeout_ids {
-            if let Some(mut cf) = self.pending_cfs.remove(&id) {
-                // Simply discard the pending_build (no rollback needed in deferred commit mode!)
+            if self.pending_cfs.remove(&id).is_some() {
+                // Discard the pending_build (deferred commit mode \u2192 no rollback)
+                // and any stored follower events / buffered votes for this CF.
                 self.pending_builds.remove(&id);
                 self.pending_cf_events.remove(&id);
                 self.buffered_votes.remove(&id);
-                cf.reject();
+            }
+            // BUG-010 follow-up: clear matching apply-failure diagnostic so it
+            // does not stick around as stale state once the offending CF is
+            // gone. Non-matching failures (different cf_id) are preserved.
+            if self
+                .last_apply_failure
+                .as_ref()
+                .is_some_and(|f| f.cf_id == id)
+            {
+                self.last_apply_failure = None;
             }
         }
         count
@@ -774,6 +885,14 @@ impl ConsensusManager {
     /// last successful finalization.
     pub fn last_apply_failure(&self) -> Option<&ApplyFailure> {
         self.last_apply_failure.as_ref()
+    }
+
+    /// Test-only: inject a synthetic apply failure so tests can verify that
+    /// `cleanup_timeout_cfs` clears the matching diagnostic (G14 keeps this
+    /// gated under `cfg(test)`).
+    #[cfg(test)]
+    pub fn set_last_apply_failure_for_testing(&mut self, failure: ApplyFailure) {
+        self.last_apply_failure = Some(failure);
     }
     
     /// Get a subnet's current state root
@@ -944,8 +1063,8 @@ mod tests {
         
         // Vote to finalize (single validator, so immediate finalization)
         manager.vote_for_cf(&cf_id, true, None);
-        let finalized = manager.check_finalization(&cf_id);
-        assert!(finalized, "CF should be finalized with single validator");
+        let outcome = manager.classify_finalization(&cf_id);
+        assert!(outcome.is_finalized(), "CF should be finalized with single validator: {:?}", outcome);
         
         // Now state should be committed
         assert_eq!(manager.anchor_count(), 1);
@@ -982,9 +1101,9 @@ mod tests {
         finalized_cf.finalize();
         let duplicate_finalized_cf = finalized_cf.clone();
 
-        assert!(manager.receive_finalized_cf(finalized_cf));
+        assert!(manager.receive_finalized_cf(finalized_cf).is_finalized());
         assert!(manager.is_finalized_cf(&cf_id));
-        assert!(!manager.receive_finalized_cf(duplicate_finalized_cf));
+        assert!(!manager.receive_finalized_cf(duplicate_finalized_cf).is_finalized());
     }
 
     // ------------------------------------------------------------------
@@ -1042,7 +1161,7 @@ mod tests {
         );
 
         manager.vote_for_cf(&cf_id, true, None);
-        assert!(manager.check_finalization(&cf_id), "CF should finalize");
+        assert!(manager.classify_finalization(&cf_id).is_finalized(), "CF should finalize");
 
         assert_eq!(
             manager.pending_builds_len_for_testing(),
@@ -1107,12 +1226,13 @@ mod tests {
         quorum_cf.add_vote(Vote::new("v2".to_string(), cf_id.clone(), true));
         quorum_cf.add_vote(Vote::new("v3".to_string(), cf_id.clone(), true));
 
-        let finalized_ok = manager.receive_finalized_cf(quorum_cf);
+        let outcome = manager.receive_finalized_cf(quorum_cf);
 
         // The CF must be REJECTED (apply failed → fail-closed).
         assert!(
-            !finalized_ok,
-            "receive_finalized_cf must return false when follower apply fails"
+            !outcome.is_finalized(),
+            "receive_finalized_cf must NOT finalize when follower apply fails: {:?}",
+            outcome
         );
         assert!(
             !manager.is_finalized_cf(&cf_id),
@@ -1150,10 +1270,241 @@ mod tests {
         let cf = manager.try_create_cf(&dag, &vlc).expect("CF");
         let cf_id = cf.id.clone();
         manager.vote_for_cf(&cf_id, true, None);
-        assert!(manager.check_finalization(&cf_id));
+        assert!(manager.classify_finalization(&cf_id).is_finalized());
 
         assert!(manager.is_finalized_cf(&cf_id));
         assert!(manager.last_apply_failure().is_none());
         assert!(manager.last_finalized_cf().is_some());
+    }
+
+    // ------------------------------------------------------------------
+    // BUG-010 follow-up tests (P0 + P1).
+    // See docs/feat/fix-bug010-finality-stall-followup/design.md §6.
+    // ------------------------------------------------------------------
+
+    /// P0-1 / Test #1: heartbeat MUST refuse to start a second pending_build
+    /// while a normal-path build is still open.
+    #[test]
+    fn followup_heartbeat_blocked_while_normal_pending() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            validator_count: 3, // > 1 so vote alone does not finalize
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(10);
+
+        // Open a normal-path build; it does not finalize because quorum needs 3.
+        let cf = manager.try_create_cf(&dag, &vlc).expect("normal CF");
+        let cf_id = cf.id.clone();
+        assert_eq!(manager.pending_builds_len_for_testing(), 1);
+
+        // Heartbeat must be suppressed while pending_build is open.
+        let hb = manager.try_create_cf_heartbeat(&dag, &vlc, std::time::Duration::from_millis(0));
+        assert!(hb.is_none(), "heartbeat must be blocked by open pending_build");
+        assert_eq!(manager.pending_builds_len_for_testing(), 1);
+
+        // Drain the pending_build by rejecting the CF (1/3+1 = 2 reject votes
+        // with validator_count=3). Two foreign reject votes suffice.
+        let v2 = Vote::new("v2".to_string(), cf_id.clone(), false);
+        let v3 = Vote::new("v3".to_string(), cf_id.clone(), false);
+        manager.receive_vote(v2);
+        let out = manager.receive_vote(v3);
+        assert!(
+            matches!(out, CfLifecycleOutcome::Rejected { .. }),
+            "expected Rejected, got {:?}",
+            out
+        );
+        assert_eq!(manager.pending_builds_len_for_testing(), 0);
+    }
+
+    /// P0-1 / Test #2: symmetric — normal path MUST refuse to start a second
+    /// pending_build while a heartbeat build is still open.
+    #[test]
+    fn followup_normal_blocked_while_heartbeat_pending() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 10_000, // high so normal-path does not fire on its own
+            min_events_per_cf: 1,
+            validator_count: 3,
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(3); // delta well below threshold
+
+        // Heartbeat with zero interval => immediate fire.
+        let hb = manager
+            .try_create_cf_heartbeat(&dag, &vlc, std::time::Duration::from_millis(0))
+            .expect("heartbeat CF");
+        let _ = hb.id;
+        assert_eq!(manager.pending_builds_len_for_testing(), 1);
+
+        // Normal path must be blocked by the open heartbeat pending_build.
+        let normal = manager.try_create_cf(&dag, &vlc);
+        assert!(
+            normal.is_none(),
+            "normal try_create_cf must be blocked by open heartbeat pending_build"
+        );
+        assert_eq!(manager.pending_builds_len_for_testing(), 1);
+    }
+
+    /// P1 / Test #3: a CF whose deferred apply fails returns
+    /// `CfLifecycleOutcome::ApplyFailed { .. }`, finalized_cfs is unchanged,
+    /// last_finalized_cf does NOT advance.
+    /// (Reuses the foreign-CF + bad-roots construction from
+    ///  `bug010_follower_apply_failure_drops_cf_and_does_not_advance`.)
+    #[test]
+    fn followup_classify_finalization_apply_failure_branch() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            validator_count: 3,
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(3);
+
+        let event_ids: Vec<_> = dag.all_events().map(|e| e.id.clone()).collect();
+        let bad_roots = AnchorMerkleRoots {
+            events_root: [0u8; 32],
+            global_state_root: [0xFFu8; 32],
+            anchor_chain_root: [0u8; 32],
+            subnet_roots: Default::default(),
+        };
+        let anchor = Anchor::with_merkle_roots(event_ids, vlc.snapshot(), bad_roots, None, 0);
+        let cf = ConsensusFrame::new(anchor, "v2".to_string());
+        let cf_id = cf.id.clone();
+        manager.receive_cf(cf.clone());
+        assert!(manager.apply_cf_state_changes(&dag, &cf));
+
+        manager.vote_for_cf(&cf_id, true, None);
+        let mut quorum_cf = cf.clone();
+        quorum_cf.add_vote(Vote::new("v1".to_string(), cf_id.clone(), true));
+        quorum_cf.add_vote(Vote::new("v2".to_string(), cf_id.clone(), true));
+        quorum_cf.add_vote(Vote::new("v3".to_string(), cf_id.clone(), true));
+
+        let outcome = manager.receive_finalized_cf(quorum_cf);
+        assert!(
+            matches!(outcome, CfLifecycleOutcome::ApplyFailed { .. }),
+            "expected ApplyFailed, got {:?}",
+            outcome
+        );
+        assert!(!manager.is_finalized_cf(&cf_id));
+        assert!(manager.last_finalized_cf().is_none());
+        assert!(manager.last_apply_failure().is_some());
+    }
+
+    /// P1 / Test #4: vote arriving after timeout must produce
+    /// `CfLifecycleOutcome::TimedOut`, not `Finalized`. This is the OBS-061
+    /// regression: previously the engine could read `last_finalized_cf()`
+    /// stale and run handle_finalization.
+    #[test]
+    fn followup_classify_finalization_timeout_branch_does_not_advance_anchor() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            cf_timeout_ms: 50,
+            validator_count: 4, // quorum = 3, so a single vote cannot finalize
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(10);
+
+        let cf = manager.try_create_cf(&dag, &vlc).expect("CF");
+        let cf_id = cf.id.clone();
+        assert_eq!(manager.pending_builds_len_for_testing(), 1);
+
+        // Wait past timeout.
+        std::thread::sleep(std::time::Duration::from_millis(80));
+
+        let late_vote = Vote::new("v2".to_string(), cf_id.clone(), true);
+        let outcome = manager.receive_vote(late_vote);
+        assert!(
+            matches!(outcome, CfLifecycleOutcome::TimedOut { .. }),
+            "expected TimedOut, got {:?}",
+            outcome
+        );
+        assert!(manager.last_finalized_cf().is_none());
+        // Step 2 guard slot is freed.
+        assert_eq!(manager.pending_builds_len_for_testing(), 0);
+    }
+
+    /// P0-2 / Test #5: cleanup_timeout_cfs frees the Step 2 guard so the
+    /// next try_create_cf can proceed.
+    #[test]
+    fn followup_cleanup_timeout_cfs_unblocks_step_2_guard() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            cf_timeout_ms: 50,
+            validator_count: 4,
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(10);
+
+        let _cf = manager.try_create_cf(&dag, &vlc).expect("CF");
+        assert_eq!(manager.pending_builds_len_for_testing(), 1);
+
+        // try_create_cf is blocked.
+        let blocked = manager.try_create_cf(&dag, &vlc);
+        assert!(blocked.is_none(), "second build must be blocked by Step 2 guard");
+
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let removed = manager.cleanup_timeout_cfs();
+        assert_eq!(removed, 1);
+        assert_eq!(manager.pending_builds_len_for_testing(), 0);
+        assert_eq!(manager.pending_cfs_len(), 0);
+    }
+
+    /// P0-2 / Test #6: cleanup clears `last_apply_failure` when its cf_id
+    /// matches a timed-out CF being removed. Non-matching failures are
+    /// preserved.
+    #[test]
+    fn followup_cleanup_timeout_cfs_clears_matching_last_apply_failure() {
+        let config = ConsensusConfig {
+            vlc_delta_threshold: 5,
+            min_events_per_cf: 1,
+            cf_timeout_ms: 50,
+            validator_count: 4,
+            ..Default::default()
+        };
+        let mut manager = ConsensusManager::new(config, "v1".to_string());
+        let (dag, vlc) = setup_dag_with_events(10);
+
+        let cf = manager.try_create_cf(&dag, &vlc).expect("CF");
+        let cf_id = cf.id.clone();
+
+        // Inject a synthetic apply failure tied to this cf_id.
+        manager.set_last_apply_failure_for_testing(ApplyFailure {
+            cf_id: cf_id.clone(),
+            anchor_id: cf.anchor.id.clone(),
+            anchor_depth: cf.anchor.depth,
+            role: ApplyFailureRole::Follower,
+            reason: "synthetic".to_string(),
+        });
+        assert!(manager.last_apply_failure().is_some());
+
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let removed = manager.cleanup_timeout_cfs();
+        assert_eq!(removed, 1);
+        assert!(
+            manager.last_apply_failure().is_none(),
+            "matching last_apply_failure must be cleared once its CF is gone"
+        );
+
+        // Non-matching failure must be preserved across cleanup.
+        manager.set_last_apply_failure_for_testing(ApplyFailure {
+            cf_id: "different-cf".to_string(),
+            anchor_id: cf.anchor.id.clone(),
+            anchor_depth: cf.anchor.depth,
+            role: ApplyFailureRole::Follower,
+            reason: "synthetic-other".to_string(),
+        });
+        let _ = manager.cleanup_timeout_cfs(); // nothing to remove
+        assert!(
+            manager.last_apply_failure().is_some(),
+            "non-matching failure must survive cleanup"
+        );
     }
 }

--- a/consensus/src/folder.rs
+++ b/consensus/src/folder.rs
@@ -593,6 +593,11 @@ impl ConsensusManager {
         self.finalized_cfs.len()
     }
 
+    #[cfg(test)]
+    pub fn has_persisted_anchor_for_testing(&self, anchor_id: &str) -> bool {
+        self.persisted_anchor_ids.contains(anchor_id)
+    }
+
     pub fn last_finalized_cf(&self) -> Option<&ConsensusFrame> {
         self.finalized_cfs.last()
     }

--- a/crates/setu-move-vm/src/engine.rs
+++ b/crates/setu-move-vm/src/engine.rs
@@ -3334,6 +3334,7 @@ mod tests {
         /// overlapping df_mutated and df_deleted maps. (Real call sites
         /// always go through `record_df_delete`, so this is a fail-safe.)
         #[test]
+        #[cfg(debug_assertions)]
         #[should_panic(expected = "df_mutated ∩ df_deleted must be empty")]
         fn test_df_mutated_and_deleted_overlap_panics_in_debug() {
             let parent = ObjectId::new([0x14; 32]);

--- a/crates/setu-network-anemo/src/transport.rs
+++ b/crates/setu-network-anemo/src/transport.rs
@@ -6,6 +6,7 @@
 use crate::{config::AnemoConfig, error::Result, AnemoError};
 use anemo::{Network, PeerId, Router};
 use bytes::Bytes;
+use std::convert::Infallible;
 use std::net::SocketAddr;
 use tracing::{debug, info};
 
@@ -17,13 +18,27 @@ pub struct AnemoTransport {
 }
 
 impl AnemoTransport {
-    /// Create a new AnemoTransport with default echo service
+    /// Create a new AnemoTransport with a default echo service
     pub async fn new(config: &AnemoConfig) -> Result<Self> {
-        Self::with_router(config, Router::new()).await
+        let echo_service = tower::service_fn(|request: anemo::Request<Bytes>| async move {
+            Ok::<_, Infallible>(anemo::Response::new(request.into_body()))
+        });
+        Self::with_service(config, echo_service).await
     }
 
     /// Create a new AnemoTransport with a custom router
     pub async fn with_router(config: &AnemoConfig, router: Router) -> Result<Self> {
+        Self::with_service(config, router).await
+    }
+
+    async fn with_service<S>(config: &AnemoConfig, service: S) -> Result<Self>
+    where
+        S: tower::Service<anemo::Request<Bytes>, Response = anemo::Response<Bytes>, Error = Infallible>
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+    {
         info!("Initializing Anemo transport on {}", config.listen_addr);
 
         // Parse listen address
@@ -43,12 +58,12 @@ impl AnemoTransport {
             key
         });
 
-        // Build the network with the router
+        // Build the network with the service
         let network = Network::bind(listen_addr)
             .server_name(&config.server_name)
             .private_key(private_key)
             .config(anemo_config)
-            .start(router)?;
+            .start(service)?;
 
         info!(
             "Anemo network started on {} with PeerId: {}",
@@ -170,7 +185,10 @@ mod tests {
         let transport2 = AnemoTransport::new(&config2).await.unwrap();
 
         // Connect transport1 to transport2
-        let peer_id = transport1.connect(transport2.local_addr()).await.unwrap();
+        let peer_id = transport1
+            .connect_with_peer_id(transport2.local_addr(), transport2.peer_id())
+            .await
+            .unwrap();
         assert_eq!(peer_id, transport2.peer_id());
 
         // Verify connection
@@ -201,6 +219,7 @@ mod tests {
         let request = anemo::Request::new(message.clone());
         let response = transport1.rpc(peer_id, request).await.unwrap();
 
+        assert_eq!(response.status(), anemo::types::response::StatusCode::Success);
         assert_eq!(response.into_body(), message);
     }
 }

--- a/deploy/dev-mult/build.sh
+++ b/deploy/dev-mult/build.sh
@@ -58,6 +58,44 @@ copy_remote_artifact_atomically() {
     return 1
 }
 
+# Single-rsync distribution: pushes all requested artifacts from BUILD_SERVER
+# to target host in ONE ssh connection instead of N. rsync writes each file to
+# a hidden tmp then renames (atomic per file), so we still get the same
+# crash-safety as copy_remote_artifact_atomically without N handshakes.
+# Returns 0 on success, non-zero if rsync missing or transfer failed; caller
+# should fall back to copy_remote_artifact_atomically.
+distribute_bundle_via_rsync() {
+    local host="$1"
+    shift
+    local artifacts=("$@")
+    local rsync_check
+    rsync_check="$(remote_exec "$BUILD_SERVER" "command -v rsync >/dev/null 2>&1 && echo ok || echo missing" 2>/dev/null | tr -d '[:space:]')"
+    if [ "$rsync_check" != "ok" ]; then
+        return 2
+    fi
+
+    local file_args=""
+    local f
+    for f in "${artifacts[@]}"; do
+        file_args="${file_args} '${REMOTE_BIN}/${f}'"
+    done
+
+    local attempt
+    for attempt in 1 2 3; do
+        if remote_exec "$BUILD_SERVER" "
+            SSHPASS='${SSH_PWD}' rsync -az --partial \\
+                -e 'sshpass -e ssh ${INNER_SSH_OPTS}' \\
+                ${file_args} \\
+                '${SSH_USER}@${host}:${REMOTE_BIN}/'
+        "; then
+            return 0
+        fi
+        print_warn "${host}: rsync 分发失败，重试 ${attempt}/3"
+        sleep 5
+    done
+    return 1
+}
+
 print_header "Setu 构建 & 分发"
 echo "  源码指纹: ${LOCAL_SOURCE_FINGERPRINT}"
 echo "  Git commit: ${LOCAL_GIT_COMMIT}"
@@ -187,22 +225,35 @@ if [ "$SKIP_DIST" = false ]; then
         fi
         local_host="${SERVERS[$i]}"
         echo "    → ${VALIDATOR_IDS[$i]} (${local_host})"
-        
+
         # 确保远程目录存在
         remote_exec "$local_host" "mkdir -p ${REMOTE_BIN}"
-        
-        # 通过构建服务器中转复制二进制
-        # 关键二进制: 失败则报错
-        for bin_name in setu-validator setu-solver; do
-            copy_remote_artifact_atomically "$local_host" "$bin_name" 1
-        done
-        # 可选二进制: 失败时静默跳过
-        for bin_name in setu-cli setu-benchmark; do
-            copy_remote_artifact_atomically "$local_host" "$bin_name" 1 2>/dev/null || true
+
+        # 收集本次实际存在的 artifact (可选二进制可能缺失)
+        bundle=(setu-validator setu-solver setu-build-info.env)
+        for opt in setu-cli setu-benchmark; do
+            if remote_exec "$BUILD_SERVER" "[ -f '${REMOTE_BIN}/${opt}' ]" 2>/dev/null; then
+                bundle+=("$opt")
+            fi
         done
 
-        copy_remote_artifact_atomically "$local_host" "setu-build-info.env" 0
-        remote_exec "$local_host" "chmod +x ${REMOTE_BIN}/* 2>/dev/null || true"
+        # 首选: 单次 rsync 分发所有 artifact (1 个 SSH 连接 vs N 个)
+        if distribute_bundle_via_rsync "$local_host" "${bundle[@]}"; then
+            print_ok "${local_host}: rsync 分发 ${#bundle[@]} 个 artifact 成功"
+        else
+            print_warn "${local_host}: rsync 不可用或失败，退回逐文件 scp"
+            # 关键二进制: 失败则报错
+            for bin_name in setu-validator setu-solver; do
+                copy_remote_artifact_atomically "$local_host" "$bin_name" 1
+            done
+            # 可选二进制: 失败时静默跳过
+            for bin_name in setu-cli setu-benchmark; do
+                copy_remote_artifact_atomically "$local_host" "$bin_name" 1 2>/dev/null || true
+            done
+            copy_remote_artifact_atomically "$local_host" "setu-build-info.env" 0
+        fi
+
+        remote_exec "$local_host" "chmod +x ${REMOTE_BIN}/setu-validator ${REMOTE_BIN}/setu-solver 2>/dev/null; chmod +x ${REMOTE_BIN}/setu-cli ${REMOTE_BIN}/setu-benchmark 2>/dev/null; true"
     done
     print_ok "二进制分发完成"
 else

--- a/deploy/dev-mult/config.sh
+++ b/deploy/dev-mult/config.sh
@@ -47,7 +47,25 @@ SSH_USER=$(_read_env 'VALIDATOR-NODE-USERNAME')
 SSH_PWD=$(_read_env 'VALIDATOR-NODE-PWD')
 SSH_USER="${SSH_USER:-root}"
 _fail_if_env_placeholder 'VALIDATOR-NODE-PWD' "$SSH_PWD"
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o LogLevel=ERROR"
+
+# ControlMaster multiplexing: one TCP+auth handshake per (user,host,port) reused
+# for N subsequent ssh/scp/rsync. Mitigates sshd MaxStartups / fail2ban
+# rate-limiting observed during deploy bursts (bug 20260421-deploy-ssh-flakiness).
+# %C = hash(user+host+port), short and collision-free across our 3 nodes.
+SSH_CTRL_DIR="${SSH_CTRL_DIR:-/tmp}"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o LogLevel=ERROR -o ControlMaster=auto -o ControlPath=${SSH_CTRL_DIR}/setu-ssh-%C -o ControlPersist=300"
+
+# Options passed inline to ssh/scp/rsync running ON a remote host (inter-VM hop in
+# remote_to_remote_copy). Mirrors SSH_OPTS but uses a distinct control path so
+# the remote side does not collide with local sockets and so we can clean them
+# independently. /tmp on Contabo Ubuntu is world-writable and persistent enough.
+INNER_SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o LogLevel=ERROR -o ControlMaster=auto -o ControlPath=/tmp/setu-bs-%C -o ControlPersist=300"
+
+# Best-effort cleanup of local ControlMaster sockets on shell exit.
+_cleanup_ssh_control_sockets() {
+    rm -f "${SSH_CTRL_DIR}"/setu-ssh-* 2>/dev/null || true
+}
+trap _cleanup_ssh_control_sockets EXIT
 
 # 构建服务器 (默认使用第一台)
 BUILD_SERVER="${SERVERS[0]}"
@@ -142,13 +160,15 @@ remote_sync() {
 
 # 服务器间复制文件: 在 from_host 上执行 scp 直接推送到 to_host
 # (避免 scp -3 双重认证问题，使用 SSHPASS 环境变量避免密码引号问题)
+# 使用 INNER_SSH_OPTS 启用 BUILD_SERVER 端的 ControlMaster，缓解 inter-VM hop
+# 的 sshd MaxStartups/fail2ban 速率限制。
 remote_to_remote_copy() {
     local from_host="$1"
     local from_path="$2"
     local to_host="$3"
     local to_path="$4"
     remote_exec "$from_host" \
-        "SSHPASS='${SSH_PWD}' sshpass -e scp -o StrictHostKeyChecking=no -o LogLevel=ERROR '${from_path}' '${SSH_USER}@${to_host}:${to_path}'"
+        "SSHPASS='${SSH_PWD}' sshpass -e scp ${INNER_SSH_OPTS} '${from_path}' '${SSH_USER}@${to_host}:${to_path}'"
 }
 
 # 等待服务健康

--- a/deploy/dev-mult/start.sh
+++ b/deploy/dev-mult/start.sh
@@ -35,7 +35,11 @@ start_validator() {
     local host="${SERVERS[$idx]}"
     local vid="${VALIDATOR_IDS[$idx]}"
     local peers
+    local callback_addr
+    local governance_timeout_secs
     peers=$(get_peer_validators "$idx")
+    callback_addr="${VALIDATOR_CALLBACK_ADDR:-${host}:${HTTP_PORT}}"
+    governance_timeout_secs="${GOVERNANCE_TIMEOUT_SECS:-300}"
 
     echo "  启动 ${vid} (${host})..."
 
@@ -64,6 +68,8 @@ start_validator() {
             GENESIS_FILE=${REMOTE_CONFIG}/genesis-remote.json \
             VALIDATOR_KEY_FILE=${REMOTE_KEYS}/${vid}.key \
             VALIDATOR_DB_PATH=${REMOTE_DATA}/db \
+            VALIDATOR_CALLBACK_ADDR=${callback_addr} \
+            GOVERNANCE_TIMEOUT_SECS=${governance_timeout_secs} \
             SETU_RAW_TRANSFER_API_TOKEN='${SETU_RAW_TRANSFER_API_TOKEN:-}' \
             RUST_LOG='${RUST_LOG}' \
             ${REMOTE_BIN}/setu-validator \
@@ -82,7 +88,7 @@ start_validator() {
     }
     
     if echo "$output" | grep -q 'STARTED'; then
-        print_ok "${vid} 已启动 (HTTP=${host}:${HTTP_PORT}, P2P=${host}:${P2P_PORT})"
+        print_ok "${vid} 已启动 (HTTP=${host}:${HTTP_PORT}, P2P=${host}:${P2P_PORT}, callback=${callback_addr})"
     else
         print_err "${vid} 启动失败! 查看日志: ./logs.sh $((idx+1))"
     fi

--- a/examples/move/counter_break/Move.toml
+++ b/examples/move/counter_break/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "CounterBreak"
+version = "0.1.0"
+
+[addresses]
+examples = "0xcafe"
+
+[dependencies]
+SetuFramework = { local = "../../../setu-framework" }

--- a/examples/move/counter_break/sources/counter.move
+++ b/examples/move/counter_break/sources/counter.move
@@ -1,0 +1,39 @@
+// A compatibility-breaking variant of examples::counter.
+// The canonical module exposes reset(); this fixture removes it so package
+// upgrade compatibility checks have a stable negative case.
+module examples::counter {
+    use setu::object::{Self, UID};
+    use setu::transfer;
+    use setu::tx_context::{Self, TxContext};
+
+    struct Counter has key, store {
+        id: UID,
+        value: u64,
+        owner: address,
+    }
+
+    public entry fun create(ctx: &mut TxContext) {
+        let counter = Counter {
+            id: object::new(ctx),
+            value: 0,
+            owner: tx_context::sender(ctx),
+        };
+        transfer::transfer(counter, tx_context::sender(ctx));
+    }
+
+    public entry fun increment(counter: &mut Counter) {
+        counter.value = counter.value + 1;
+    }
+
+    public entry fun increment_by(counter: &mut Counter, amount: u64) {
+        counter.value = counter.value + amount;
+    }
+
+    public fun value(counter: &Counter): u64 {
+        counter.value
+    }
+
+    public entry fun transfer_to(counter: Counter, recipient: address) {
+        transfer::transfer(counter, recipient);
+    }
+}

--- a/setu-validator/src/consensus_integration.rs
+++ b/setu-validator/src/consensus_integration.rs
@@ -934,6 +934,16 @@ impl ConsensusValidator {
 
         Ok(())
     }
+
+    /// Periodic maintenance: time out stale pending CFs.
+    ///
+    /// BUG-010 follow-up: Task D in `main.rs` ticks this on a 2s cadence so
+    /// a pending CF that never reaches quorum cannot permanently block the
+    /// one-in-flight `pending_builds` slot. Thin forwarder to
+    /// `ConsensusEngine::run_periodic_maintenance`.
+    pub async fn run_periodic_maintenance(&self) {
+        self.engine.run_periodic_maintenance().await;
+    }
     
     /// Get the local validator ID
     pub fn validator_id(&self) -> &str {

--- a/setu-validator/src/consensus_integration.rs
+++ b/setu-validator/src/consensus_integration.rs
@@ -616,10 +616,12 @@ impl ConsensusValidator {
         // In single-node mode, add_event() → try_create_cf() → check_finalization()
         // may finalize a CF immediately. The internal message channel is not consumed
         // in production, so we must persist here synchronously.
-        let mut any_persisted = false;
         for anchor in self.engine.take_pending_anchors().await {
             match self.persist_finalized_anchor(&anchor).await {
-                Ok(()) => { any_persisted = true; }
+                Ok(()) => {
+                    // P2 fix: mark this anchor as persisted so its CF can broadcast
+                    self.engine.mark_anchor_persisted(&anchor.id).await;
+                }
                 Err(e) => {
                     warn!(
                         anchor_id = %anchor.id,
@@ -630,13 +632,10 @@ impl ConsensusValidator {
             }
         }
         // Layer A: only run post-persist completion (broadcast + advance round)
-        // after at least one anchor durably persisted. If all persists failed,
-        // the queued completions stay in the engine and will be retried by the
-        // next caller invocation.
-        if any_persisted {
-            if let Err(e) = self.engine.complete_pending_finalizations().await {
-                warn!(error = %e, "complete_pending_finalizations failed after submit_event persist");
-            }
+        // after at least one anchor durably persisted. Unpersisted anchors remain
+        // queued until the next persist attempt (idempotent under restart).
+        if let Err(e) = self.engine.complete_pending_finalizations().await {
+            warn!(error = %e, "complete_pending_finalizations failed after submit_event persist");
         }
         
         Ok(event_id)
@@ -684,7 +683,8 @@ impl ConsensusValidator {
                 );
                 match self.persist_finalized_anchor(a).await {
                     Ok(()) => {
-                        // Layer A: trigger post-persist broadcast + round advance.
+                        // P2 fix: mark anchor as persisted so its CF broadcasts
+                        self.engine.mark_anchor_persisted(&a.id).await;
                         if let Err(e) = self.engine.complete_pending_finalizations().await {
                             warn!(error = %e, "complete_pending_finalizations failed after receive_cf persist");
                         }
@@ -727,6 +727,8 @@ impl ConsensusValidator {
                 );
                 match self.persist_finalized_anchor(a).await {
                     Ok(()) => {
+                        // P2 fix: mark anchor as persisted so its CF broadcasts
+                        self.engine.mark_anchor_persisted(&a.id).await;
                         if let Err(e) = self.engine.complete_pending_finalizations().await {
                             warn!(error = %e, "complete_pending_finalizations failed after receive_vote persist");
                         }
@@ -881,8 +883,8 @@ impl ConsensusValidator {
         self.engine.get_subnet_state_root(subnet_id).await
     }
     
-    /// Mark an anchor as persisted (for safe GC)
-    pub async fn mark_anchor_persisted(&self, anchor_id: &str) {
+    /// Mark an anchor as persisted (for safe GC and completion queue purposes)
+    pub async fn mark_anchor_persisted(&self, anchor_id: &setu_types::AnchorId) {
         self.engine.mark_anchor_persisted(anchor_id).await;
     }
     
@@ -919,14 +921,14 @@ impl ConsensusValidator {
 
         if result.is_some() {
             // Persist any inline-finalized anchors (same as submit_event)
-            let mut any_persisted = false;
             for anchor in self.engine.take_pending_anchors().await {
                 if self.persist_finalized_anchor(&anchor).await.is_ok() {
-                    any_persisted = true;
+                    // P2 fix: mark this anchor as persisted so its CF can broadcast
+                    self.engine.mark_anchor_persisted(&anchor.id).await;
                 }
             }
-            if any_persisted {
-                let _ = self.engine.complete_pending_finalizations().await;
+            if let Err(e) = self.engine.complete_pending_finalizations().await {
+                warn!(error = %e, "complete_pending_finalizations failed after receive_cf persist");
             }
         }
 
@@ -1355,7 +1357,7 @@ mod tests {
 
     /// F8: Layer A — `handle_finalization` enqueues the CF in
     /// `pending_completions` but does NOT advance round or broadcast until
-    /// `complete_pending_finalizations()` is called.
+    /// the anchor is marked persisted and `complete_pending_finalizations()` is called.
     #[tokio::test]
     async fn test_f8_finalization_defers_broadcast_until_complete() {
         let mut config = create_test_config();
@@ -1375,6 +1377,12 @@ mod tests {
         // Layer A: round must NOT advance pre-completion.
         assert_eq!(engine.current_round().await, 0);
 
+        engine.complete_pending_finalizations().await.unwrap();
+        assert_eq!(engine.current_round().await, 0);
+
+        engine
+            .mark_anchor_persisted(&anchor.as_ref().unwrap().id)
+            .await;
         engine.complete_pending_finalizations().await.unwrap();
         // After completion: round advances exactly once.
         assert_eq!(engine.current_round().await, 1);

--- a/setu-validator/src/main.rs
+++ b/setu-validator/src/main.rs
@@ -1174,6 +1174,22 @@ async fn main() -> anyhow::Result<()> {
             }
         });
         info!("✓ Heartbeat CF task started (5s interval)");
+
+        // Task D — Periodic maintenance: time out stale pending CFs so a
+        // single stuck CF cannot permanently hold the in-flight
+        // `pending_builds` slot (BUG-010 follow-up). 2s cadence is short
+        // enough to recover quickly after a partial vote loss; the actual
+        // timeout threshold is governed by `cf_timeout_ms`.
+        let maintenance_cv = Arc::clone(&consensus_validator);
+        let _maintenance_handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(2));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                maintenance_cv.run_periodic_maintenance().await;
+            }
+        });
+        info!("✓ Periodic maintenance task started (2s interval)");
     }
 
     // Spawn HTTP server

--- a/setu-validator/src/network/registration.rs
+++ b/setu-validator/src/network/registration.rs
@@ -24,6 +24,57 @@ pub struct ValidatorRegistrationHandler {
     pub(crate) service: Arc<ValidatorNetworkService>,
 }
 
+fn validate_public_subnet_id(raw: &str) -> Result<String, &'static str> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err("Invalid subnet_id: must not be empty");
+    }
+    if value != raw {
+        return Err("Invalid subnet_id: leading/trailing whitespace is not allowed");
+    }
+    if value.len() < 3 || value.len() > 64 {
+        return Err("Invalid subnet_id: length must be 3-64 characters");
+    }
+    if value.eq_ignore_ascii_case("root") || value.eq_ignore_ascii_case("governance") {
+        return Err("Invalid subnet_id: reserved system id");
+    }
+
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err("Invalid subnet_id: must not be empty");
+    };
+    let last = value.chars().last().unwrap_or(first);
+    if !first.is_ascii_alphanumeric() || !last.is_ascii_alphanumeric() {
+        return Err("Invalid subnet_id: must start and end with a letter or digit");
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        return Err("Invalid subnet_id: only lowercase letters, digits, and '-' are allowed");
+    }
+
+    Ok(value.to_string())
+}
+
+fn validate_public_subnet_name(raw: &str) -> Result<String, &'static str> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err("Invalid subnet name: must not be empty");
+    }
+    if value != raw {
+        return Err("Invalid subnet name: leading/trailing whitespace is not allowed");
+    }
+    if raw.chars().count() > 128 {
+        return Err("Invalid subnet name: length must be <= 128 characters");
+    }
+    if raw.chars().any(|ch| ch.is_control()) {
+        return Err("Invalid subnet name: control characters are not allowed");
+    }
+
+    Ok(raw.to_string())
+}
+
 #[async_trait::async_trait]
 impl RegistrationHandler for ValidatorRegistrationHandler {
     async fn register_solver(&self, request: RegisterSolverRequest) -> RegisterSolverResponse {
@@ -222,21 +273,45 @@ impl RegistrationHandler for ValidatorRegistrationHandler {
     }
 
     async fn register_subnet(&self, request: RegisterSubnetRequest) -> RegisterSubnetResponse {
+        let subnet_id = match validate_public_subnet_id(&request.subnet_id) {
+            Ok(value) => value,
+            Err(message) => {
+                return RegisterSubnetResponse {
+                    success: false,
+                    message: message.to_string(),
+                    subnet_id: None,
+                    event_id: None,
+                };
+            }
+        };
+
+        let subnet_name = match validate_public_subnet_name(&request.name) {
+            Ok(value) => value,
+            Err(message) => {
+                return RegisterSubnetResponse {
+                    success: false,
+                    message: message.to_string(),
+                    subnet_id: None,
+                    event_id: None,
+                };
+            }
+        };
+
         info!(
-            subnet_id = %request.subnet_id,
-            name = %request.name,
+            subnet_id = %subnet_id,
+            name = %subnet_name,
             owner = %request.owner,
             token_symbol = %request.token_symbol,
             "Processing subnet registration"
         );
 
         // Check if already registered
-        if self.service.get_subnet_info(&request.subnet_id).is_some() {
-            warn!(subnet_id = %request.subnet_id, "Subnet already registered");
+        if self.service.get_subnet_info(&subnet_id).is_some() {
+            warn!(subnet_id = %subnet_id, "Subnet already registered");
             return RegisterSubnetResponse {
                 success: false,
-                message: format!("Subnet '{}' is already registered", request.subnet_id),
-                subnet_id: Some(request.subnet_id),
+                message: format!("Subnet '{}' is already registered", subnet_id),
+                subnet_id: Some(subnet_id),
                 event_id: None,
             };
         }
@@ -309,8 +384,8 @@ impl RegistrationHandler for ValidatorRegistrationHandler {
 
         // Build SubnetRegistration
         let mut registration = SubnetRegistration::new(
-            request.subnet_id.clone(),
-            request.name.clone(),
+            subnet_id.clone(),
+            subnet_name.clone(),
             request.owner.clone(),
             request.token_symbol.clone(),
         )
@@ -358,7 +433,7 @@ impl RegistrationHandler for ValidatorRegistrationHandler {
         {
             Ok(event) => event,
             Err(e) => {
-                tracing::error!(subnet_id = %request.subnet_id, error = %e,
+                tracing::error!(subnet_id = %subnet_id, error = %e,
                     "InfraExecutor subnet registration failed");
                 return RegisterSubnetResponse {
                     success: false,
@@ -375,7 +450,7 @@ impl RegistrationHandler for ValidatorRegistrationHandler {
         let submit_response = self.service.add_event_to_dag(event).await;
         if !submit_response.success {
             warn!(
-                subnet_id = %request.subnet_id,
+                subnet_id = %subnet_id,
                 message = %submit_response.message,
                 "Subnet registration DAG submission failed"
             );
@@ -388,8 +463,8 @@ impl RegistrationHandler for ValidatorRegistrationHandler {
         }
 
         self.service.add_subnet(SubnetInfo {
-            subnet_id: request.subnet_id.clone(),
-            name: request.name.clone(),
+            subnet_id: subnet_id.clone(),
+            name: subnet_name,
             owner: request.owner.clone(),
             subnet_type: format!("{:?}", registration.subnet_type),
             token_symbol: request.token_symbol.clone(),
@@ -401,7 +476,7 @@ impl RegistrationHandler for ValidatorRegistrationHandler {
         });
 
         info!(
-            subnet_id = %request.subnet_id,
+            subnet_id = %subnet_id,
             event_id = %&event_id[..20.min(event_id.len())],
             "Subnet registered successfully"
         );
@@ -409,7 +484,7 @@ impl RegistrationHandler for ValidatorRegistrationHandler {
         RegisterSubnetResponse {
             success: true,
             message: "Subnet registered successfully".to_string(),
-            subnet_id: Some(request.subnet_id),
+            subnet_id: Some(subnet_id),
             event_id: Some(event_id),
         }
     }

--- a/setu-validator/src/network/service.rs
+++ b/setu-validator/src/network/service.rs
@@ -15,7 +15,6 @@
 //!
 //! This module implements several optimizations for high throughput:
 //! - DashMap for lock-free concurrent access to transfer_status, events, solver_info
-//! - Reverse index (solver_pending_transfers) to avoid O(n) scans
 //! - Lock-free VLC allocation via atomic counter
 
 use super::registration::ValidatorRegistrationHandler;
@@ -102,9 +101,6 @@ pub struct ValidatorNetworkService {
 
     /// Transfer tracking - uses DashMap for lock-free concurrent access
     transfer_status: Arc<DashMap<String, TransferTracker>>,
-
-    /// Reverse index: solver_id -> pending transfer_ids (for O(1) lookup)
-    solver_pending_transfers: Arc<DashMap<String, Vec<String>>>,
 
     /// Event storage - uses DashMap for lock-free concurrent access
     events: Arc<DashMap<String, Event>>,
@@ -216,7 +212,6 @@ impl ValidatorNetworkService {
             solver_channels: Arc::new(RwLock::new(HashMap::new())),
             http_client,
             transfer_status,
-            solver_pending_transfers: Arc::new(DashMap::new()),
             events,
             pending_events: Arc::new(RwLock::new(Vec::new())),
             dag_events,
@@ -304,7 +299,6 @@ impl ValidatorNetworkService {
             solver_channels: Arc::new(RwLock::new(HashMap::new())),
             http_client,
             transfer_status,
-            solver_pending_transfers: Arc::new(DashMap::new()),
             events,
             pending_events: Arc::new(RwLock::new(Vec::new())),
             dag_events,
@@ -620,7 +614,6 @@ impl ValidatorNetworkService {
             &self.task_preparer,
             &self.coin_reservation_manager,
             &self.transfer_status,
-            &self.solver_pending_transfers,
             &self.transfer_counter,
             vlc_time,
             request,
@@ -658,7 +651,6 @@ impl ValidatorNetworkService {
             &self.batch_task_preparer,
             &self.coin_reservation_manager,
             &self.transfer_status,
-            &self.solver_pending_transfers,
             &self.transfer_counter,
             &self.vlc_counter,
             request,

--- a/setu-validator/src/network/service.rs
+++ b/setu-validator/src/network/service.rs
@@ -2366,6 +2366,33 @@ mod tests {
         });
     }
 
+    async fn assert_invalid_subnet_request_rejected(
+        request: setu_rpc::RegisterSubnetRequest,
+        rejected_subnet_id: &str,
+        expected_markers: &[&str],
+    ) {
+        let service = create_test_service();
+        let handler = service.registration_handler();
+        service.force_next_add_event_to_dag_response(forced_submit_failure());
+
+        let response = handler.register_subnet(request).await;
+
+        assert!(!response.success);
+        assert_eq!(response.subnet_id, None);
+        assert_eq!(response.event_id, None);
+        assert!(
+            expected_markers
+                .iter()
+                .all(|marker| response.message.contains(marker)),
+            "message '{}' did not contain expected markers {:?}",
+            response.message,
+            expected_markers
+        );
+        assert!(!response.message.contains("forced submit failure"));
+        assert!(service.get_subnet_info(rejected_subnet_id).is_none());
+        assert!(service.forced_add_event_response.read().is_some());
+    }
+
     fn seed_membership(service: &ValidatorNetworkService, address: &str, subnet_id: &str) {
         let membership_key = format!("user:{}:subnet:{}", address, subnet_id);
         let membership_oid = setu_types::ObjectId::new(
@@ -2536,6 +2563,156 @@ mod tests {
         assert_eq!(response.event_id, None);
         assert!(response.message.contains("forced submit failure"));
         assert!(service.get_subnet_info("subnet-fail").is_none());
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_empty_subnet_id() {
+        let request = sample_subnet_request("");
+
+        assert_invalid_subnet_request_rejected(
+            request,
+            "",
+            &["Invalid subnet_id", "empty"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_whitespace_subnet_id() {
+        let request = sample_subnet_request("   ");
+
+        assert_invalid_subnet_request_rejected(
+            request,
+            "   ",
+            &["Invalid subnet_id", "empty"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_malformed_subnet_id_with_spaces() {
+        let request = sample_subnet_request("p0 bad id test");
+
+        assert_invalid_subnet_request_rejected(
+            request,
+            "p0 bad id test",
+            &["Invalid subnet_id"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_uppercase_subnet_id() {
+        let request = sample_subnet_request("P0-App");
+
+        assert_invalid_subnet_request_rejected(
+            request,
+            "P0-App",
+            &["Invalid subnet_id", "lowercase"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_reserved_subnet_id() {
+        let root_request = sample_subnet_request("ROOT");
+        assert_invalid_subnet_request_rejected(
+            root_request,
+            "ROOT",
+            &["Invalid subnet_id", "reserved"],
+        )
+        .await;
+
+        let governance_request = sample_subnet_request("governance");
+        assert_invalid_subnet_request_rejected(
+            governance_request,
+            "governance",
+            &["Invalid subnet_id", "reserved"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_empty_name() {
+        let mut request = sample_subnet_request("p0-empty-name-test");
+        request.name = "".to_string();
+
+        assert_invalid_subnet_request_rejected(
+            request,
+            "p0-empty-name-test",
+            &["Invalid subnet name", "empty"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_whitespace_name() {
+        let mut request = sample_subnet_request("p0-whitespace-name-test");
+        request.name = "  ".to_string();
+
+        assert_invalid_subnet_request_rejected(
+            request,
+            "p0-whitespace-name-test",
+            &["Invalid subnet name", "empty"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_rejects_name_with_control_char() {
+        let mut request = sample_subnet_request("p0-control-name-test");
+        request.name = "bad\nname".to_string();
+
+        assert_invalid_subnet_request_rejected(
+            request,
+            "p0-control-name-test",
+            &["Invalid subnet name", "control"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn register_subnet_validates_before_duplicate_check() {
+        let service = create_test_service();
+        let handler = service.registration_handler();
+        let invalid_id = "p0 bad id duplicate";
+        add_test_subnet(&service, invalid_id);
+        service.force_next_add_event_to_dag_response(forced_submit_failure());
+
+        let response = handler
+            .register_subnet(sample_subnet_request(invalid_id))
+            .await;
+
+        assert!(!response.success);
+        assert_eq!(response.subnet_id, None);
+        assert_eq!(response.event_id, None);
+        assert!(response.message.contains("Invalid subnet_id"));
+        assert!(!response.message.contains("already registered"));
+        assert!(!response.message.contains("forced submit failure"));
+        assert!(service.get_subnet_info(invalid_id).is_some());
+        assert!(service.forced_add_event_response.read().is_some());
+    }
+
+    #[tokio::test]
+    async fn register_subnet_accepts_valid_slug_and_name() {
+        let service = create_test_service();
+        let handler = service.registration_handler();
+        let mut request = sample_subnet_request("p0-valid-app");
+        request.name = "P0 Valid App".to_string();
+
+        let response = handler.register_subnet(request).await;
+
+        assert!(response.success, "{}", response.message);
+        assert_eq!(response.subnet_id, Some("p0-valid-app".to_string()));
+        assert!(response
+            .event_id
+            .as_ref()
+            .map(|event_id| !event_id.is_empty())
+            .unwrap_or(false));
+        let subnet = service
+            .get_subnet_info("p0-valid-app")
+            .expect("valid subnet should be registered");
+        assert_eq!(subnet.name, "P0 Valid App");
     }
 
     #[tokio::test]

--- a/setu-validator/src/network/transfer_handler.rs
+++ b/setu-validator/src/network/transfer_handler.rs
@@ -49,7 +49,6 @@ impl TransferHandler {
         task_preparer: &TaskPreparer,
         coin_reservation_manager: &CoinReservationManager,
         transfer_status: &Arc<DashMap<String, TransferTracker>>,
-        solver_pending_transfers: &Arc<DashMap<String, Vec<String>>>,
         transfer_counter: &AtomicU64,
         vlc_time: u64,
         request: SubmitTransferRequest,
@@ -201,14 +200,6 @@ impl TransferHandler {
                 created_at: now,
             },
         );
-
-        // Add to reverse index for O(1) lookup during TEE completion
-        if let Some(ref sid) = solver_id {
-            solver_pending_transfers
-                .entry(sid.clone())
-                .or_insert_with(Vec::new)
-                .push(transfer_id.clone());
-        }
 
         // Step 6: Execute Solver INLINE (await) → release coin → submit consensus
         //
@@ -393,7 +384,6 @@ impl TransferHandler {
         batch_preparer: &BatchTaskPreparer,
         coin_reservation_manager: &CoinReservationManager,
         transfer_status: &Arc<DashMap<String, TransferTracker>>,
-        solver_pending_transfers: &Arc<DashMap<String, Vec<String>>>,
         transfer_counter: &AtomicU64,
         vlc_counter: &AtomicU64,
         request: SubmitTransfersBatchRequest,
@@ -554,12 +544,6 @@ impl TransferHandler {
                                 created_at: now,
                             },
                         );
-
-                        // Add to reverse index
-                        solver_pending_transfers
-                            .entry(solver_id.clone())
-                            .or_insert_with(Vec::new)
-                            .push(transfer_id.clone());
 
                         // Spawn TEE task with reservation (reservation will be released after task completion)
                         tee_executor.spawn_tee_task_with_reservation(

--- a/setu-validator/src/persistence.rs
+++ b/setu-validator/src/persistence.rs
@@ -202,6 +202,7 @@ pub trait FinalizationPersister: Send + Sync {
             // late-queued CF index entries so they do not leak; a failure
             // here may still escalate after MAX_CF_INDEX_RETRIES tries.
             self.persist_pending_finalized_cfs().await?;
+            self.engine().mark_anchor_persisted(&anchor.id).await;
             debug!(anchor_id = %anchor.id, "Anchor already persisted, skipping (idempotent)");
             return Ok(());
         }
@@ -418,7 +419,7 @@ mod tests {
                     // mirrors warn!(...) — error is logged then swallowed
                 }
             } else {
-                cf_store.mark_finalized(&cf.id).await;
+                let _ = cf_store.mark_finalized(&cf.id).await;
             }
         }
         pending

--- a/storage/src/rocks/core/db.rs
+++ b/storage/src/rocks/core/db.rs
@@ -41,18 +41,42 @@ impl SetuDB {
             .ok_or_else(|| StorageError::cf_not_found(cf.name()))
     }
 
-    /// Serialize a key using bincode
+    /// Serialize a key using bincode 2.0-rc.3.
+    ///
+    /// **CODEC CONTRACT** (G6): Keys MUST always use bincode. This is non-negotiable
+    /// across all SetuDB operations. Values use BCS (see `encode_value`).
+    /// Mixing codecs (e.g., decoding bincode-encoded key as BCS) produces silent
+    /// data corruption or decode panics in recovery/diagnostic paths.
+    ///
+    /// **Recovery note**: Any manual RocksDB read or migration tool that reads
+    /// bytes from disk MUST verify the codec assumption before decoding.
+    /// See `docs/testnet/deferred-bugs-priority-assessment-20260519.md#p1-high`.
     fn encode_key<K: Encode>(key: &K) -> Result<Vec<u8>> {
         bincode::encode_to_vec(key, bincode::config::standard())
             .map_err(|e| StorageError::serialization(e.to_string()))
     }
 
-    /// Serialize a value using BCS (Binary Canonical Serialization)
+    /// Serialize a value using BCS (Binary Canonical Serialization).
+    ///
+    /// **CODEC CONTRACT** (G6): Values MUST always use BCS. Keys use bincode
+    /// (see `encode_key`). This split is required for Merkle consistency and
+    /// canonical serialization. Any code that needs to read raw bytes from
+    /// RocksDB and decode them with a different codec (e.g., migration tools,
+    /// recovery utilities, diagnostic scripts) MUST verify codec assumptions
+    /// and fail loudly if they don't match.
     fn encode_value<V: Serialize>(value: &V) -> Result<Vec<u8>> {
         bcs::to_bytes(value).map_err(|e| StorageError::serialization(e.to_string()))
     }
 
-    /// Deserialize a value using BCS
+    /// Deserialize a value using BCS.
+    ///
+    /// **CODEC CONTRACT** (G6): Values MUST always decode with BCS. If you are
+    /// adding a new field to a BCS-serialized struct (e.g., Event, ExecutionResult,
+    /// StateChange), BCS has no `#[serde(default)]` escape hatch — existing bytes
+    /// will fail to decode. Plan schema changes carefully.
+    ///
+    /// If decode fails, the error is NOT silent; it propagates up. This is correct
+    /// behavior and MUST NOT be silently swallowed in recovery/replay paths.
     fn decode_value<V: DeserializeOwned>(bytes: &[u8]) -> Result<V> {
         bcs::from_bytes(bytes).map_err(|e| StorageError::deserialization(e.to_string()))
     }
@@ -149,7 +173,12 @@ impl SetuDB {
         Ok(())
     }
 
-    /// Get a value by raw byte key
+    /// Get a value by raw byte key.
+    ///
+    /// **CODEC CONTRACT**: Values are decoded with BCS. If you are reading from
+    /// a CF that was written via a different code path or a prior version that
+    /// used a different codec, this will fail or produce wrong data. Always verify
+    /// assumptions about which codec produced the bytes before calling this.
     pub fn get_raw<V>(&self, cf: ColumnFamily, key: &[u8]) -> Result<Option<V>>
     where
         V: DeserializeOwned,

--- a/storage/src/rocks/event_store.rs
+++ b/storage/src/rocks/event_store.rs
@@ -6,7 +6,7 @@
 //! ## Key Design Decisions
 //!
 //! 1. **Composite Keys for Depth**: Uses `depth:{event_id}` prefix keys for depth storage
-//! 2. **Depth Reverse Index**: Uses `depthidx:{depth:08x}:{event_id}` for efficient range queries
+//! 2. **Depth Reverse Index**: Uses `depthidx:{depth:016x}:{event_id}` for efficient range queries
 //! 3. **Atomic Batch Writes**: Uses WriteBatch for atomic store_with_depth operations
 //! 4. **API Compatible**: Maintains the same async API as in-memory EventStore
 //! 5. **Index Tables**: Stores by_creator and by_status as separate key prefixes
@@ -16,7 +16,7 @@
 //! All data is stored in ColumnFamily::Events:
 //! - `evt:{event_id}` -> Event (main event data)
 //! - `depth:{event_id}` -> u64 (depth information)
-//! - `depthidx:{depth:08x}:{event_id}` -> () (depth reverse index for range queries)
+//! - `depthidx:{depth:016x}:{event_id}` -> () (depth reverse index for range queries)
 //! - `creator:{creator}:{event_id}` -> () (creator index)
 //! - `status:{status}:{event_id}` -> () (status index)
 
@@ -35,6 +35,8 @@ mod key_prefix {
     pub const CREATOR: &[u8] = b"creator:";
     pub const STATUS: &[u8] = b"status:";
 }
+
+const DEPTH_IDX_HEX_WIDTH: usize = 16;
 
 /// RocksDB-backed EventStore implementation
 pub struct RocksDBEventStore {
@@ -75,17 +77,26 @@ impl RocksDBEventStore {
         key
     }
 
-    /// Depth index key: `depthidx:{depth:08x}:{event_id}` → ()
+    /// Depth index key: `depthidx:{depth:016x}:{event_id}` → ()
     /// Enables efficient range scans by depth without full-table scan.
     fn depth_idx_key(depth: u64, event_id: &EventId) -> Vec<u8> {
-        // "depthidx:" + 8-char hex + ":" + event_id
-        let formatted = format!("depthidx:{:08x}:{}", depth, event_id);
+        let formatted = format!(
+            "depthidx:{:0width$x}:{}",
+            depth,
+            event_id,
+            width = DEPTH_IDX_HEX_WIDTH
+        );
         formatted.into_bytes()
     }
 
-    /// Prefix for all events at a specific depth: `depthidx:{depth:08x}:`
+    /// Prefix for all events at a specific depth: `depthidx:{depth:016x}:`
     fn depth_idx_prefix_for_depth(depth: u64) -> Vec<u8> {
-        format!("depthidx:{:08x}:", depth).into_bytes()
+        format!(
+            "depthidx:{:0width$x}:",
+            depth,
+            width = DEPTH_IDX_HEX_WIDTH
+        )
+        .into_bytes()
     }
 
     fn creator_key(creator: &str, event_id: &EventId) -> Vec<u8> {
@@ -659,13 +670,13 @@ impl EventStoreBackend for RocksDBEventStore {
             }
 
             for key in keys {
-                // Key format: "depthidx:{depth:08x}:{event_id}"
+                // Key format: "depthidx:{depth:016x}:{event_id}"
                 let key_str = match String::from_utf8(key) {
                     Ok(s) => s,
                     Err(_) => continue,
                 };
-                // Skip past "depthidx:XXXXXXXX:"
-                let event_id = match key_str.get(("depthidx:".len() + 8 + 1)..) {
+                let event_id_start = key_prefix::DEPTH_IDX.len() + DEPTH_IDX_HEX_WIDTH + 1;
+                let event_id = match key_str.get(event_id_start..) {
                     Some(id) if !id.is_empty() => id.to_string(),
                     _ => continue,
                 };
@@ -719,9 +730,11 @@ impl EventStoreBackend for RocksDBEventStore {
         let idx_prefix = key_prefix::DEPTH_IDX;
         if let Ok(keys) = self.db.prefix_scan_keys(ColumnFamily::Events, idx_prefix) {
             if let Some(last_key) = keys.last() {
-                // Key format: "depthidx:{depth:08x}:{event_id}"
+                // Key format: "depthidx:{depth:016x}:{event_id}"
                 if let Ok(key_str) = String::from_utf8(last_key.clone()) {
-                    if let Some(hex_str) = key_str.get("depthidx:".len().."depthidx:".len() + 8) {
+                    let depth_start = key_prefix::DEPTH_IDX.len();
+                    let depth_end = depth_start + DEPTH_IDX_HEX_WIDTH;
+                    if let Some(hex_str) = key_str.get(depth_start..depth_end) {
                         if let Ok(depth) = u64::from_str_radix(hex_str, 16) {
                             return Some(depth);
                         }
@@ -773,6 +786,111 @@ mod tests {
             setu_types::VLCSnapshot::new(),
             creator.to_string(),
         )
+    }
+
+    #[test]
+    fn depthidx_key_uses_full_u64_width() {
+        let event_id: EventId = "event-high".to_string();
+        let key = String::from_utf8(RocksDBEventStore::depth_idx_key(0x1_0000_0000, &event_id))
+            .expect("depthidx key must be utf8");
+        assert_eq!(key, "depthidx:0000000100000000:event-high");
+
+        let prefix = String::from_utf8(RocksDBEventStore::depth_idx_prefix_for_depth(
+            0x1_0000_0000,
+        ))
+        .expect("depthidx prefix must be utf8");
+        assert_eq!(prefix, "depthidx:0000000100000000:");
+    }
+
+    #[tokio::test]
+    async fn depthidx_get_max_depth_orders_across_u32_boundary() {
+        let temp_dir = tempfile::tempdir().expect("temp dir must be created");
+        let store = RocksDBEventStore::new(
+            SetuDB::open_default(temp_dir.path()).expect("test db must open"),
+        );
+        let low_depth = 0xffff_ffff;
+        let high_depth = 0x1_0000_0000;
+
+        store
+            .store_with_depth(test_event("depth-low"), low_depth)
+            .await
+            .expect("low depth event must store");
+        store
+            .store_with_depth(test_event("depth-high"), high_depth)
+            .await
+            .expect("high depth event must store");
+
+        assert_eq!(store.get_max_depth().await, Some(high_depth));
+    }
+
+    #[tokio::test]
+    async fn depthidx_range_returns_events_across_u32_boundary() {
+        let temp_dir = tempfile::tempdir().expect("temp dir must be created");
+        let store = RocksDBEventStore::new(
+            SetuDB::open_default(temp_dir.path()).expect("test db must open"),
+        );
+        let low_depth = 0xffff_ffff;
+        let high_depth = 0x1_0000_0000;
+        let low_event = test_event("depth-range-low");
+        let high_event = test_event("depth-range-high");
+        let low_id = low_event.id.clone();
+        let high_id = high_event.id.clone();
+
+        store
+            .store_with_depth(low_event, low_depth)
+            .await
+            .expect("low depth event must store");
+        store
+            .store_with_depth(high_event, high_depth)
+            .await
+            .expect("high depth event must store");
+
+        let events = store
+            .get_events_by_depth_range(low_depth, high_depth)
+            .await
+            .expect("depth range must load");
+        let observed: Vec<(EventId, u64)> = events
+            .into_iter()
+            .map(|(event, depth)| (event.id, depth))
+            .collect();
+
+        assert_eq!(observed, vec![(low_id, low_depth), (high_id, high_depth)]);
+    }
+
+    #[tokio::test]
+    async fn depthidx_range_orders_multiple_events_at_high_depth() {
+        let temp_dir = tempfile::tempdir().expect("temp dir must be created");
+        let store = RocksDBEventStore::new(
+            SetuDB::open_default(temp_dir.path()).expect("test db must open"),
+        );
+        let depth = 0x1_0000_0000;
+        let event_a = test_event("depth-same-a");
+        let event_b = test_event("depth-same-b");
+        let mut expected = vec![event_a.id.clone(), event_b.id.clone()];
+        expected.sort();
+
+        store
+            .store_with_depth(event_b, depth)
+            .await
+            .expect("event b must store");
+        store
+            .store_with_depth(event_a, depth)
+            .await
+            .expect("event a must store");
+
+        let events = store
+            .get_events_by_depth_range(depth, depth)
+            .await
+            .expect("depth range must load");
+        let observed: Vec<EventId> = events
+            .into_iter()
+            .map(|(event, event_depth)| {
+                assert_eq!(event_depth, depth);
+                event.id
+            })
+            .collect();
+
+        assert_eq!(observed, expected);
     }
 
     #[tokio::test]

--- a/storage/src/state/manager.rs
+++ b/storage/src/state/manager.rs
@@ -605,6 +605,11 @@ impl GlobalStateManager {
     /// 4. Verify reconstructed root matches persisted root (consistency check)
     /// 5. Restore last anchor info from MerkleMeta
     ///
+    /// **CODEC ASSUMPTIONS** (G6): Recovery decodes all values with BCS (from SetuDB).
+    /// If RocksDB was written with a different codec (e.g., by a diagnostic tool or
+    /// corrupt migration), decode will fail or produce wrong data. This is correct
+    /// behavior — recovery should fail loudly on codec mismatches, not silently corrupt.
+    ///
     /// ## Returns
     ///
     /// Returns a `RecoverySummary` with statistics about the recovery.


### PR DESCRIPTION
## Summary

A V1-testnet hardening pass covering 8 fix commits against `upstream/main` (21 files, +1732 / -332). The biggest change is closing the BUG-010 multi-validator finality stall in two stages, plus a related "broadcast-before-persist" ordering fix in the consensus/validator path. The rest are smaller correctness, validation, and operational fixes accumulated alongside the V1 P0/P1 launch work.

No protocol/storage schema changes. No `EventType` variant changes. No public API shape changes.

## Commits

Listed oldest → newest as they appear on `feat/parallel`.

1. `0d2a12c` **fix(network-anemo): restore default transport echo service** — `AnemoTransport::new` now starts the documented echo service via a shared `with_service` helper; `with_router` still supports custom routers.
2. `68a0539` **fix(v1): commit launch code fixes** — V1 P0 cluster:
   - storage: encode `depthidx` keys with a shared 16-hex-digit width so `u64` lexicographic replay order matches numeric order.
   - validator: drop the unused `solver_pending_transfers` reverse index and its append plumbing.
   - examples/move: restore the `CounterBreak` fixture (without `reset()`) so package-upgrade compatibility-negative coverage still compiles.
3. `05b6fb3` **fix(consensus): gate CF completion on anchor persistence** — queue CF side effects per anchor and only run them after the matching anchor is durably persisted; preserve `ConsensusManager` persisted-anchor GC marking and idempotent persistence semantics; gate a Move VM debug-only panic test in release builds.
4. `5ad6429` **fix(deploy): reduce dev-mult ssh handshake bursts** — SSH `ControlMaster` multiplexing for `remote_exec` / `remote_copy` / `remote_sync`, `INNER_SSH_OPTS` for build-server inter-VM hops, and one-shot rsync distribution with the per-file scp path kept as fallback. Shell-only; no Rust/Cargo changes.
5. `7d0e89d` **fix(deploy): propagate governance callback env in dev-mult start** — pass the governance callback env into the start script.
6. `cc40f10` **fix(validator): reject invalid app subnet registrations** — validate the public `subnet_id` and name before duplicate lookup, event construction, DAG submission, and registry mutation; new network tests cover malformed ids, reserved ids, empty names, validation-before-duplicate, and the valid registration path. RPC/event payload types unchanged; submit-response side-effect gating preserved.
7. `b82fc2a` **fix(consensus): fail-closed on CF apply error and one `pending_build` per round (BUG-010)** — closes the primary BUG-010 mechanism (apply-failure masquerading as finalized) and a secondary parallel-CF-from-one-base trigger:
   - On `commit_build` error, snapshot-mismatch → follower-fallback error, or follower deferred-apply error, the CF is now **dropped**: `finalized_cfs` is not pushed, `synchronize_finalized_anchor` is not called, `last_apply_failure` is set, and `check_finalization` returns false. Events stay in `dag.events` for re-fold (liveness preserved).
   - New Step 2 guard at the top of `try_create_cf` rejects starting a second `prepare_build` while one is already open for the current round.
   - Inverts and renames a test that had codified the BUG-010 behavior as intended (`test_follower_rejects_cf_with_mismatched_global_state_root`).
8. `1c3bf18` **fix(consensus): close BUG-010 follow-up gaps — heartbeat guard, typed CF outcome, periodic CF GC** — addresses three residual gaps from the previous commit:
   - **Gap-1**: extract `can_start_new_pending_build()` and gate **both** `try_create_cf` (normal) and `try_create_cf_heartbeat`.
   - **Gap-3**: replace `check_finalization() -> bool` with `classify_finalization() -> CfLifecycleOutcome { Pending, Finalized, ApplyFailed, Rejected, TimedOut }`; propagate the typed outcome through `receive_vote` / `receive_finalized_cf`; migrate all 5 engine sites to `matches!` + explicit `ApplyFailed` logging; delete `manager_last_finalized_matches`.
   - **Gap-2**: wire `cleanup_timeout_cfs` (which now also clears matching `last_apply_failure` and drops a dead post-remove `cf.reject()`) into a new validator `Task D` — `tokio::interval(2s)` → `engine.run_periodic_maintenance()`.
   - Add structured `consensus::diag::prepare_build_entry` trace before every `prepare_build*` so the next hot-burst run can grep for `pending_builds_count > 1` per `(proposer, round)`.