### PR TITLE
fix: heartbeat timestamp unit, transfer normalization, validator propagation, error handling

### DIFF
--- a/crates/setu-network-anemo/src/generic_handler.rs
+++ b/crates/setu-network-anemo/src/generic_handler.rs
@@ -110,8 +110,12 @@ where
                         Ok(Response::new(Bytes::new()))
                     }
                     Err(e) => {
-                        tracing::warn!("Handler error: {}", e);
-                        Ok(Response::new(Bytes::new()))
+                        tracing::warn!("Handler error on route {}: {}", route, e);
+                        // Return the error as the response body instead of silently
+                        // swallowing it. Callers can detect errors by checking for
+                        // the "__HANDLER_ERROR__:" prefix.
+                        let error_body = format!("__HANDLER_ERROR__:{e}");
+                        Ok(Response::new(Bytes::from(error_body)))
                     }
                 }
             }

--- a/setu-rpc/src/registration.rs
+++ b/setu-rpc/src/registration.rs
@@ -208,7 +208,7 @@ impl RegistrationClient {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_secs();
+            .as_millis() as u64;
         
         let request = HeartbeatRequest {
             node_id,

--- a/setu-validator/src/consensus_integration.rs
+++ b/setu-validator/src/consensus_integration.rs
@@ -847,8 +847,12 @@ impl ConsensusValidator {
         let mut vs = self.validator_set.write().await;
         vs.add_validator(info.clone());
         
-        // Also register in TEE verifier if they have a public key
-        // (This would be extended in a real implementation)
+        // Also update the engine's ValidatorSet + ConsensusManager.validator_count
+        // so the new validator is visible to quorum/leader election logic.
+        // Without this, the validator exists in the local copy but is invisible
+        // to the consensus engine.
+        drop(vs);
+        self.engine.add_consensus_validator(info.clone()).await;
         
         info!(
             validator_id = %info.node.id,

--- a/setu-validator/src/user_handler.rs
+++ b/setu-validator/src/user_handler.rs
@@ -1142,8 +1142,8 @@ impl UserRpcHandler for ValidatorUserHandler {
         // Forward the canonical subnet id (D1); no local side effects before
         // DAG submission succeeds or fails inside submit_transfer.
         let submit_request = SubmitTransferRequest {
-            from: request.from,
-            to: request.to,
+            from: normalized_from,
+            to: normalized_to,
             amount: amount_units,
             transfer_type: "setu".to_string(),
             resources: vec![],


### PR DESCRIPTION
## Summary

Fixes 4 bugs across the RPC, validator, and network layers:

### 1. Heartbeat timestamp: seconds instead of milliseconds
**`setu-rpc/src/registration.rs:208`**

The heartbeat client used `as_secs()` to produce the timestamp, but every other timestamp in the codebase uses milliseconds (discovery `timestamp_ms`, state sync `last_update_ms`, config timeouts in `_ms`). Any staleness check was off by 1000×, causing false timeout or false alive decisions.

**Fix:** `as_secs()` → `as_millis() as u64`

### 2. Transfer forwards unnormalized addresses — anti-replay bypass
**`setu-validator/src/user_handler.rs:1144`**

The anti-replay precheck and canonical signature used `normalized_from`/`normalized_to` (lowercase), but `SubmitTransferRequest` forwarded the original-case `request.from`/`request.to`. If the downstream TEE runtime derives the nonce marker object from the unnormalized address, it computes a **different** marker than the one pre-checked, rendering the anti-replay defense ineffective.

**Fix:** Forward `normalized_from`/`normalized_to` instead of `request.from`/`request.to`

### 3. `add_validator` not propagated to consensus engine
**`setu-validator/src/consensus_integration.rs:846`**

`add_validator()` updated the local `ValidatorSet` copy but did NOT call `self.engine.add_consensus_validator(info)`. This meant new validators added via this path were invisible to quorum calculation and leader election. `add_peer_validator()` (line 475) already did this correctly.

**Fix:** Added `self.engine.add_consensus_validator(info).await` after the local update

### 4. GenericHandler swallows errors — returns 200 OK with empty body
**`crates/setu-network-anemo/src/generic_handler.rs:112`**

When a message handler returned `Err(e)`, the service wrapper logged a warning and returned `Ok(Response::new(Bytes::new()))` — a 200 OK with empty body. Callers had no way to distinguish an error from a legitimate empty response.

**Fix:** Return the error message in the response body with a `__HANDLER_ERROR__:` prefix so callers can detect and parse errors.

## Testing

- `cargo check -p setu-rpc -p setu-validator -p setu-network-anemo` — passes
- `cargo test -p setu-rpc -p setu-network-anemo` — all pass
- `cargo test -p consensus -p setu-types` — 338/339 pass (1 pre-existing golden-file failure)

## Files changed

- `setu-rpc/src/registration.rs` — `as_secs()` → `as_millis() as u64`
- `setu-validator/src/user_handler.rs` — forward normalized addresses
- `setu-validator/src/consensus_integration.rs` — propagate to engine
- `crates/setu-network-anemo/src/generic_handler.rs` — encode error in response